### PR TITLE
ARM: dts: revpi-flat-overlay: set max-frequency for sdhci

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -338,7 +338,7 @@
 			status = "okay";
 			bus-width = <4>;
 			non-removable;
-			brcm,overclock-50 = <20>;
+			max-frequency = <28000000>;
 
 			wlan0: wifi@1 {
 				reg = <1>;


### PR DESCRIPTION
The muRata LBEE5HY1MW wifi module is connected to the sdhci controller.
The modules max freqency in data transfer mode is 25MHz (SDR). It should
be able to run at up to 50MHz (DDR). But with freqencys > 27,777 MHz the
device can't be probed:

mmc1: queuing unknown CIS tuple 0x80 (2 bytes)
mmc1: queuing unknown CIS tuple 0x80 (3 bytes)
mmc1: queuing unknown CIS tuple 0x80 (3 bytes)
mmc1: queuing unknown CIS tuple 0x80 (7 bytes)
mmc1: queuing unknown CIS tuple 0x80 (6 bytes)
mmc0: sdhost-bcm2835 loaded - DMA enabled (>1)
mmc1: error -110 whilst initialising SDIO card

This might be a Problem with the bottom to top board connector.

The base parent clock is 250MHz so the following frequencies are
possible:
125MHz, 83.3MHz, 62.5MHz, 50MHz, 41.6MHz, 35.7MHz, 31.3MHz, 27.8MHZ,
25MHz, ...

So we limit the mmc max-freqeuency to 28MHz. The MMC driver will then
take the next slower freq (27.8MHz).

The brcm,overclock-50 property is not suitable for this. It only
effects overclocking with > 50MHz correctly. The correct way to limit
the clock is to set the max-frequency of the mmc-host.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>