### PR TITLE
Feature/revpi 754 read mac from otp

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -1402,7 +1402,7 @@ static void smsc95xx_unbind(struct usbnet *dev, struct usb_interface *intf)
 	struct smsc95xx_priv *pdata = (struct smsc95xx_priv *)(dev->data[0]);
 
 	if (pdata) {
-		cancel_delayed_work(&pdata->carrier_check);
+		cancel_delayed_work_sync(&pdata->carrier_check);
 		netif_dbg(dev, ifdown, dev->net, "free pdata\n");
 		kfree(pdata);
 		pdata = NULL;

--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -1371,7 +1371,8 @@ static int smsc95xx_bind(struct usbnet *dev, struct usb_interface *intf)
 	/* detect device revision as different features may be available */
 	ret = smsc95xx_read_reg(dev, ID_REV, &val);
 	if (ret < 0)
-		return ret;
+		goto free_pdata;
+
 	val >>= 16;
 	pdata->chip_id = val;
 	pdata->mdix_ctrl = get_mdix_status(dev->net);

--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -1365,6 +1365,8 @@ static int smsc95xx_bind(struct usbnet *dev, struct usb_interface *intf)
 
 	/* Init all registers */
 	ret = smsc95xx_reset(dev);
+	if (ret)
+		goto free_pdata;
 
 	/* detect device revision as different features may be available */
 	ret = smsc95xx_read_reg(dev, ID_REV, &val);
@@ -1395,6 +1397,10 @@ static int smsc95xx_bind(struct usbnet *dev, struct usb_interface *intf)
 	schedule_delayed_work(&pdata->carrier_check, CARRIER_CHECK_DELAY);
 
 	return 0;
+
+free_pdata:
+	kfree(pdata);
+	return ret;
 }
 
 static void smsc95xx_unbind(struct usbnet *dev, struct usb_interface *intf)

--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -929,48 +929,48 @@ static int smsc95xx_ioctl(struct net_device *netdev, struct ifreq *rq, int cmd)
 /* Check the macaddr module parameter for a MAC address */
 static int smsc95xx_is_macaddr_param(struct usbnet *dev, u8 *dev_mac)
 {
-       int i, j, got_num, num;
-       u8 mtbl[MAC_ADDR_LEN];
+	int i, j, got_num, num;
+	u8 mtbl[MAC_ADDR_LEN];
 
-       if (macaddr[0] == ':')
-               return 0;
+	if (macaddr[0] == ':')
+		return 0;
 
-       i = 0;
-       j = 0;
-       num = 0;
-       got_num = 0;
-       while (j < MAC_ADDR_LEN) {
-               if (macaddr[i] && macaddr[i] != ':') {
-                       got_num++;
-                       if ('0' <= macaddr[i] && macaddr[i] <= '9')
-                               num = num * 16 + macaddr[i] - '0';
-                       else if ('A' <= macaddr[i] && macaddr[i] <= 'F')
-                               num = num * 16 + 10 + macaddr[i] - 'A';
-                       else if ('a' <= macaddr[i] && macaddr[i] <= 'f')
-                               num = num * 16 + 10 + macaddr[i] - 'a';
-                       else
-                               break;
-                       i++;
-               } else if (got_num == 2) {
-                       mtbl[j++] = (u8) num;
-                       num = 0;
-                       got_num = 0;
-                       i++;
-               } else {
-                       break;
-               }
-       }
+	i = 0;
+	j = 0;
+	num = 0;
+	got_num = 0;
+	while (j < MAC_ADDR_LEN) {
+		if (macaddr[i] && macaddr[i] != ':') {
+			got_num++;
+			if ('0' <= macaddr[i] && macaddr[i] <= '9')
+				num = num * 16 + macaddr[i] - '0';
+			else if ('A' <= macaddr[i] && macaddr[i] <= 'F')
+				num = num * 16 + 10 + macaddr[i] - 'A';
+			else if ('a' <= macaddr[i] && macaddr[i] <= 'f')
+				num = num * 16 + 10 + macaddr[i] - 'a';
+			else
+				break;
+			i++;
+		} else if (got_num == 2) {
+			mtbl[j++] = (u8) num;
+			num = 0;
+			got_num = 0;
+			i++;
+		} else {
+			break;
+		}
+	}
 
-       if (j == MAC_ADDR_LEN) {
-               netif_dbg(dev, ifup, dev->net, "Overriding MAC address with: "
-               "%02x:%02x:%02x:%02x:%02x:%02x\n", mtbl[0], mtbl[1], mtbl[2],
-                                               mtbl[3], mtbl[4], mtbl[5]);
-               for (i = 0; i < MAC_ADDR_LEN; i++)
-                       dev_mac[i] = mtbl[i];
-               return 1;
-       } else {
-               return 0;
-       }
+	if (j == MAC_ADDR_LEN) {
+		netif_dbg(dev, ifup, dev->net, "Overriding MAC address with: "
+		"%02x:%02x:%02x:%02x:%02x:%02x\n", mtbl[0], mtbl[1], mtbl[2],
+						mtbl[3], mtbl[4], mtbl[5]);
+		for (i = 0; i < MAC_ADDR_LEN; i++)
+			dev_mac[i] = mtbl[i];
+		return 1;
+	} else {
+		return 0;
+	}
 }
 
 static void smsc95xx_init_mac_address(struct usbnet *dev)


### PR DESCRIPTION
smsc95xx:
- cherry picked some fixes from upstream
- minor cleanup
- add support form mac address from the module parameter for multiple devices

As the firmware of the revpi reads the mac from otp and sets it in the cmdline this is the proper way to get the mac from the otp.