### PR TITLE
arm/dts/revpi-*: make kunbus compatible highest priority

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
@@ -16,8 +16,8 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
-			compatible = "brcm,bcm2837", "brcm,bcm2836",
-				     "kunbus,revpi-compact";
+			compatible = "kunbus,revpi-compact", "brcm,bcm2837",
+				     "brcm,bcm2836";
 
 			aout_vref: fixedregulator_2v5x4 {
 				compatible = "regulator-fixed";

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -16,8 +16,8 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
-			compatible = "brcm,bcm2837", "brcm,bcm2836",
-				     "kunbus,revpi-connect";
+			compatible = "kunbus,revpi-connect", "brcm,bcm2837",
+				     "brcm,bcm2836";
 
 			leds {
 				compatible = "gpio-leds";

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -16,8 +16,8 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
-			compatible = "brcm,bcm2837", "brcm,bcm2836",
-				     "brcm,bcm2835", "kunbus,revpi-core";
+			compatible = "kunbus,revpi-core", "brcm,bcm2837",
+				     "brcm,bcm2836", "brcm,bcm2835";
 
 			leds {
 				compatible = "gpio-leds";

--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -17,8 +17,8 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
-			compatible = "brcm,bcm2837", "brcm,bcm2836",
-				     "kunbus,revpi-flat";
+			compatible = "kunbus,revpi-flat", "brcm,bcm2837",
+				     "brcm,bcm2836";
 
 			aout_vref: fixedregulator_2v5x4 {
 				compatible = "regulator-fixed";


### PR DESCRIPTION
As the compatibles should be listed from specific to more general the
kunbus,<board> compatible should be listed first. This is the only way
to match it with udev rules or to write a board/platform driver only for
the matching board.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>