### PR TITLE
flat-overlay: remove already defined labels

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -111,29 +111,11 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
-			i2c0_gpio44: i2c0_gpio44 {
-				brcm,pins = <44 45>;
-				brcm,function = <BCM2835_FSEL_ALT1>;
-			};
-			i2c1_gpio2: i2c1_gpio2 {
-				brcm,pins = <2 3>;
-				brcm,function = <BCM2835_FSEL_ALT0>;
-			};
-			spi0_cs_pins: spi0_cs_pins {
+			spi0_cs_pins {
 				/* aout ain mbus tpm */
 				brcm,pins     = <8 7 6 30>;
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
-			};
-			emmc_gpio34: emmc_gpio34 {
-				brcm,pins = <34 35 36 37 38 39>;
-				brcm,function = <BCM2835_FSEL_ALT3>;
-				brcm,pull = <BCM2835_PUD_OFF
-					     BCM2835_PUD_UP
-					     BCM2835_PUD_UP
-					     BCM2835_PUD_UP
-					     BCM2835_PUD_UP
-					     BCM2835_PUD_UP>;
 			};
 			tpm_pins {
 				/* irq reset */


### PR DESCRIPTION
The application of the device tree overlay to the generic raspberry
device-tree failed if applied via the command dtoverlay.

The reason is that some node labels that were already defined in the
generic device tree, were redefined by the flat-overlay.
While the bootloader seems to tolerate those duplicates (i.e. if the
overlay is applied by setting dtoverlay=revpi-flat in /boot/config.txt),
dtoverlay failes with the error message "* Failed to apply overlay
'0_revpi-flat' (kernel)"

To fix this remove the duplicates which are:
2c0_gpio44:	already defined in arch/arm/boot/dts/bcm283x.dtsi
i2c1_gpio2:	already defined in arch/arm/boot/dts/bcm283x.dtsi
emmc_gpio34:	already defined in arch/arm/boot/dts/bcm2837-rpi-3-b-plus.dts
spi0_cs_pins:	already defined in arch/arm/boot/dts/bcm2837-rpi-3-b-plus.dts

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>