### PR TITLE
net: dsa: tag_ksz: dont let the hardware process the layer 4 checksum

### DIFF
--- a/net/dsa/tag_ksz.c
+++ b/net/dsa/tag_ksz.c
@@ -56,6 +56,9 @@ static struct sk_buff *ksz8795_xmit(struct sk_buff *skb, struct net_device *dev)
 	if (skb_linearize(skb))
 		return NULL;
 
+	if (skb->ip_summed == CHECKSUM_PARTIAL && skb_checksum_help(skb))
+		return NULL;
+
 	/* Tag encoding */
 	tag = skb_put(skb, KSZ_INGRESS_TAG_LEN);
 	addr = skb_mac_header(skb);
@@ -121,6 +124,9 @@ static struct sk_buff *ksz9477_xmit(struct sk_buff *skb,
 	if (skb_linearize(skb))
 		return NULL;
 
+	if (skb->ip_summed == CHECKSUM_PARTIAL && skb_checksum_help(skb))
+		return NULL;
+
 	/* Tag encoding */
 	tag = skb_put(skb, KSZ9477_INGRESS_TAG_LEN);
 	addr = skb_mac_header(skb);
@@ -173,6 +179,9 @@ static struct sk_buff *ksz9893_xmit(struct sk_buff *skb,
 	u8 *tag;
 
 	if (skb_linearize(skb))
+		return NULL;
+
+	if (skb->ip_summed == CHECKSUM_PARTIAL && skb_checksum_help(skb))
 		return NULL;
 
 	/* Tag encoding */


### PR DESCRIPTION
If the checksum calculation is offloaded to the network device (e.g due to
NETIF_F_HW_CSUM inherited from the DSA master device), the calculated
layer 4 checksum is incorrect. This is since the DSA tag which is placed
after the layer 4 data is considered as being part of the daa and thus
errorneously included into the checksum calculation.
To avoid this, always calculate the layer 4 checksum in software.

TODO: check if upstream solution is available and use that instead of this
patch

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>