### PR TITLE
net: dsa: tag_ksz: linearize SKB before adding DSA tag

### DIFF
--- a/net/dsa/tag_ksz.c
+++ b/net/dsa/tag_ksz.c
@@ -53,6 +53,9 @@ static struct sk_buff *ksz8795_xmit(struct sk_buff *skb, struct net_device *dev)
 	u8 *tag;
 	u8 *addr;
 
+	if (skb_linearize(skb))
+		return NULL;
+
 	/* Tag encoding */
 	tag = skb_put(skb, KSZ_INGRESS_TAG_LEN);
 	addr = skb_mac_header(skb);
@@ -115,6 +118,9 @@ static struct sk_buff *ksz9477_xmit(struct sk_buff *skb,
 	u8 *addr;
 	u16 val;
 
+	if (skb_linearize(skb))
+		return NULL;
+
 	/* Tag encoding */
 	tag = skb_put(skb, KSZ9477_INGRESS_TAG_LEN);
 	addr = skb_mac_header(skb);
@@ -165,6 +171,9 @@ static struct sk_buff *ksz9893_xmit(struct sk_buff *skb,
 	struct dsa_port *dp = dsa_slave_to_port(dev);
 	u8 *addr;
 	u8 *tag;
+
+	if (skb_linearize(skb))
+		return NULL;
 
 	/* Tag encoding */
 	tag = skb_put(skb, KSZ_INGRESS_TAG_LEN);


### PR DESCRIPTION
In ksz9477_xmit() skb_put() is used to add the DSA tag to the passed SKB.
However skb_put() must only be called for linear SKBs which may not be the
case if the DSA slave device inherited NETIF_F_SG from the master device.
So make sure the SKB is always linearized.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>