### PR TITLE
arm(64)/dts/connect4: Reduce SPI frequency of KSZ9897

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -199,7 +199,12 @@
 			ksz9897: ksz9897@0 {
 				compatible = "microchip,ksz9897";
 				reg = <0>;
-				spi-max-frequency = <50000000>;
+				/*
+				 * Limit frequency to 25MHz to avoid data
+				 * corruption due to interferences with USB
+				 * signals.
+				 */
+				spi-max-frequency = <25000000>;
 				spi-cpha;
 				spi-cpol;
 				reset-gpios = <&expander_core 13 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
It turned out that if the SPI frequency for accessing the KSZ9897 is too
high (more than 33MHz) the data read from the PHY registers may be
corrupted if at the same time the USB is accessed. This may be caused by
interferences between the SPI and USB signals.
However reducing the frequency to a value below or equal to 33MHz for the
SPI communication with the switch eliminates this effect.
To be on the save side choose a value of 25MHz.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>