### PR TITLE
arm(64)/dts/connect4: Enable PCF2129 watchdog

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -159,6 +159,7 @@
 				compatible = "nxp,pcf2129";
 				reg = <0x51>;
 				status = "okay";
+				reset-source;
 			};
 		};
 	};


### PR DESCRIPTION
Since commit 757cd94ac859 (rtc: pcf2127: only use watchdog when explicitly
available) the watchdog of the PCF2129 needs to be enabled explicitly.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>