### PR TITLE
serial: amba-pl011: do not request memory region twice [REVPI-1633]

### DIFF
--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -2220,31 +2220,12 @@ static const char *pl011_type(struct uart_port *port)
 }
 
 /*
- * Release the memory region(s) being used by 'port'
- */
-static void pl011_release_port(struct uart_port *port)
-{
-	release_mem_region(port->mapbase, SZ_4K);
-}
-
-/*
- * Request the memory region(s) being used by 'port'
- */
-static int pl011_request_port(struct uart_port *port)
-{
-	return request_mem_region(port->mapbase, SZ_4K, "uart-pl011")
-			!= NULL ? 0 : -EBUSY;
-}
-
-/*
  * Configure/autoconfigure the port.
  */
 static void pl011_config_port(struct uart_port *port, int flags)
 {
-	if (flags & UART_CONFIG_TYPE) {
+	if (flags & UART_CONFIG_TYPE)
 		port->type = PORT_AMBA;
-		pl011_request_port(port);
-	}
 }
 
 /*
@@ -2258,6 +2239,8 @@ static int pl011_verify_port(struct uart_port *port, struct serial_struct *ser)
 	if (ser->irq < 0 || ser->irq >= nr_irqs)
 		ret = -EINVAL;
 	if (ser->baud_base < 9600)
+		ret = -EINVAL;
+	if (port->mapbase != (unsigned long) ser->iomem_base)
 		ret = -EINVAL;
 	return ret;
 }
@@ -2313,8 +2296,6 @@ static const struct uart_ops amba_pl011_pops = {
 	.flush_buffer	= pl011_dma_flush_buffer,
 	.set_termios	= pl011_set_termios,
 	.type		= pl011_type,
-	.release_port	= pl011_release_port,
-	.request_port	= pl011_request_port,
 	.config_port	= pl011_config_port,
 	.verify_port	= pl011_verify_port,
 #ifdef CONFIG_CONSOLE_POLL
@@ -2344,8 +2325,6 @@ static const struct uart_ops sbsa_uart_pops = {
 	.shutdown	= sbsa_uart_shutdown,
 	.set_termios	= sbsa_uart_set_termios,
 	.type		= pl011_type,
-	.release_port	= pl011_release_port,
-	.request_port	= pl011_request_port,
 	.config_port	= pl011_config_port,
 	.verify_port	= pl011_verify_port,
 #ifdef CONFIG_CONSOLE_POLL


### PR DESCRIPTION
The driver requests and releases the io memory for a uart port twice: First
the memory is allocated and mapped as a managed resource in
pl011_setup_port(). Then the same memory is requested again as an unmanaged
resource in pl011_request_port().
The second request fails due to the already claimed resource (note that the
failure remains unnoticed, since the concerning return value is not
evaluated).

This leads to a "Trying to free nonexistent resource" warning when the
unmanaged resource is supposed to be freed in pl011_release_port() at
module unload.

Fix this by removing the superfluous functions that implement the unmanaged
version of the memory request/release.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>