### PR TITLE
serial: 8250: Allow rs485 bus termination GPIO access to sleep on RT

### DIFF
--- a/drivers/tty/serial/8250/8250_port.c
+++ b/drivers/tty/serial/8250/8250_port.c
@@ -687,8 +687,8 @@ int serial8250_em485_config(struct uart_port *port, struct serial_rs485 *rs485)
 	memset(rs485->padding, 0, sizeof(rs485->padding));
 	port->rs485 = *rs485;
 
-	gpiod_set_value(port->rs485_term_gpio,
-			rs485->flags & SER_RS485_TERMINATE_BUS);
+	gpiod_set_value_cansleep_rt(port->rs485_term_gpio,
+				    rs485->flags & SER_RS485_TERMINATE_BUS);
 
 	/*
 	 * Both serial8250_em485_init() and serial8250_em485_destroy()

--- a/include/linux/gpio/consumer.h
+++ b/include/linux/gpio/consumer.h
@@ -740,4 +740,12 @@ static inline void gpiod_unexport(struct gpio_desc *desc)
 
 #endif /* CONFIG_GPIOLIB && CONFIG_GPIO_SYSFS */
 
+#ifdef CONFIG_PREEMPT_RT_FULL
+#define gpiod_get_value_cansleep_rt gpiod_get_value_cansleep
+#define gpiod_set_value_cansleep_rt gpiod_set_value_cansleep
+#else
+#define gpiod_get_value_cansleep_rt gpiod_get_value
+#define gpiod_set_value_cansleep_rt gpiod_set_value
+#endif
+
 #endif


### PR DESCRIPTION
The "RevPi Connect Flat" PLC offered by KUNBUS connects the rs485 bus
termination GPIO to an i2c-attached GPIO expander.  Communication with
the expander may sleep, so the GPIO pin cannot be accessed in spinlocked
context.  Yet readout and changing of rs485 bus termination happens with
the uart_port spinlock held.  The result is a WARN splat on every access
to the GPIO pin because the _cansleep() variant of the GPIO API isn't
used.

Fortunately, on RT, spinlocks become sleeping locks, so accessing the
rs485 bus termination GPIOs is actually safe and the WARN splat is
a false positive.

Therefore, provide _cansleep_rt() variants of gpiod_set_value() and
gpiod_get_value() which become _cansleep() if CONFIG_PREEMPT_RT_FULL
is enabled.  Use those new variants when accessing the rs485 bus
termination GPIO.

Signed-off-by: Lukas Wunner <lukas@wunner.de>
(cherry picked from commit e09e5ed9e3267e9e877a995d5d5e302bffcc1669)
Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>