### PR TITLE
revpi-4.19: Remove support to set the MAC addr on Flat in the DT [REVPI-1756]

### DIFF
--- a/Documentation/devicetree/bindings/net/wireless/brcm,bcm43xx-fmac.txt
+++ b/Documentation/devicetree/bindings/net/wireless/brcm,bcm43xx-fmac.txt
@@ -15,7 +15,6 @@ Optional properties:
 	When not specified the device will use in-band SDIO interrupts.
  - interrupt-names : name of the out-of-band interrupt, which must be set
 	to "host-wake".
- - local-mac-address : see ethernet.txt in the parent directory
 
 Example:
 
@@ -35,6 +34,5 @@ mmc3: mmc@1c12000 {
 		interrupt-parent = <&pio>;
 		interrupts = <10 8>; /* PH10 / EINT10 */
 		interrupt-names = "host-wake";
-                local-mac-address = [00 00 00 00 00 00];
 	};
 };

--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -332,7 +332,6 @@
 			wlan0: wifi@1 {
 				reg = <1>;
 				compatible = "brcm,bcm4329-fmac";
-				local-mac-address = [00 00 00 00 00 00];
 				status = "okay";
 			};
 		};
@@ -377,8 +376,6 @@
 		eth0_mac_lo = <&eth0>,"local-mac-address;4";
 		eth1_mac_hi = <&eth1>,"local-mac-address:0";
 		eth1_mac_lo = <&eth1>,"local-mac-address;4";
-		wlan0_mac_hi = <&wlan0>,"local-mac-address:0";
-		wlan0_mac_lo = <&wlan0>,"local-mac-address;4";
 		bootargs = <&chosen_overlay>,"bootargs";
 	};
 };

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
@@ -210,14 +210,12 @@ int brcmf_c_preinit_dcmds(struct brcmf_if *ifp)
 	char *ptr;
 	s32 err;
 
-	if (!is_valid_ether_addr(ifp->mac_addr)) {
-		/* retreive mac address */
-		err = brcmf_fil_iovar_data_get(ifp, "cur_etheraddr", ifp->mac_addr,
-					       sizeof(ifp->mac_addr));
-		if (err < 0) {
-			brcmf_err("Retreiving cur_etheraddr failed, %d\n", err);
-			goto done;
-		}
+	/* retreive mac address */
+	err = brcmf_fil_iovar_data_get(ifp, "cur_etheraddr", ifp->mac_addr,
+				       sizeof(ifp->mac_addr));
+	if (err < 0) {
+		brcmf_err("Retreiving cur_etheraddr failed, %d\n", err);
+		goto done;
 	}
 	memcpy(ifp->drvr->wiphy->perm_addr, ifp->drvr->mac, ETH_ALEN);
 	memcpy(ifp->drvr->mac, ifp->mac_addr, sizeof(ifp->drvr->mac));

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.h
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.h
@@ -59,7 +59,6 @@ struct brcmf_mp_device {
 	bool		iapp;
 	bool		ignore_probe_fail;
 	struct brcmfmac_pd_cc *country_codes;
-	u8 mac_addr[ETH_ALEN];
 	union {
 		struct brcmfmac_sdio_pd sdio;
 	} bus;

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/core.c
@@ -1055,8 +1055,6 @@ static int brcmf_bus_started(struct brcmf_pub *drvr, struct cfg80211_ops *ops)
 	if (ret < 0)
 		goto fail;
 
-	ether_addr_copy(ifp->mac_addr, drvr->settings->mac_addr);
-
 	/* Bus is ready, do any initialization */
 	ret = brcmf_c_preinit_dcmds(ifp);
 	if (ret < 0)

--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/of.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/of.c
@@ -15,7 +15,6 @@
  */
 #include <linux/init.h>
 #include <linux/of.h>
-#include <linux/of_net.h>
 #include <linux/of_irq.h>
 
 #include <defs.h>
@@ -29,7 +28,6 @@ void brcmf_of_probe(struct device *dev, enum brcmf_bus_type bus_type,
 {
 	struct brcmfmac_sdio_pd *sdio = &settings->bus.sdio;
 	struct device_node *np = dev->of_node;
-	const unsigned char *mac_addr;
 	int irq;
 	u32 irqf;
 	u32 val;
@@ -40,10 +38,6 @@ void brcmf_of_probe(struct device *dev, enum brcmf_bus_type bus_type,
 
 	if (of_property_read_u32(np, "brcm,drive-strength", &val) == 0)
 		sdio->drive_strength = val;
-
-	mac_addr = of_get_mac_address(np);
-	if (mac_addr && is_valid_ether_addr(mac_addr))
-		ether_addr_copy(settings->mac_addr, mac_addr);
 
 	/* make sure there are interrupts defined in the node */
 	if (!of_find_property(np, "interrupts", NULL))


### PR DESCRIPTION
The support to set the MAC address in the devicetree has never worked correctly. Just remove it, then the original MAC address of the device is used. This way the device works until we implement a proper solution.