### PR TITLE
serial: 8250: Fix define for conditional compilation

### DIFF
--- a/include/linux/gpio/consumer.h
+++ b/include/linux/gpio/consumer.h
@@ -740,7 +740,7 @@ static inline void gpiod_unexport(struct gpio_desc *desc)
 
 #endif /* CONFIG_GPIOLIB && CONFIG_GPIO_SYSFS */
 
-#ifdef CONFIG_PREEMPT_RT_FULL
+#ifdef CONFIG_PREEMPT_RT
 #define gpiod_get_value_cansleep_rt gpiod_get_value_cansleep
 #define gpiod_set_value_cansleep_rt gpiod_set_value_cansleep
 #else


### PR DESCRIPTION
The define CONFIG_PREEMPT_RT_FULL is used to switch from non-sleepable to
sleepable gpio access in realtime kernels. However this macro does not
exist any more so the switch has not effect and also for realtime kernels
the non-sleepable gpio access is used. Fix this by using the correct define
for newer kernels.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>