### PR TITLE
CI: Run snapshot builds also on merge

### DIFF
--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -1,12 +1,15 @@
 name: Build
 on:
+  push:
+    branches:
+      - devel/revpi-5.10
   pull_request:
     types:
       - labeled
 jobs:
   kernelbakery_snapshot:
     name: snapshot
-    if: ${{ github.event.label.name == 'snapshot-packages' }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') || github.event_name == 'push' }}
     uses:  RevolutionPi/ci-workflows/.github/workflows/kernel-snapshot.yml@main
     with:
       kernelbakery_branch: devel/5.10


### PR DESCRIPTION
As discussed earlier this PR adds another trigger for our CI. The snapshot builds are now also triggered when a PR is merged into `devel/5.10`

Signed-off-by: Nicolai Buchwitz <nb+github@tipi-net.de>