### PR TITLE
dts: revpi-core: pull down sniff pin

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -66,6 +66,9 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&sniff_a_pins>;
+
 			spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
@@ -88,6 +91,12 @@
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			sniff_a_pins: pb_sniff_a_pins {
+				/* A2 */
+				brcm,pins     = <28>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+				brcm,pull     = <BCM2835_PUD_DOWN>;
 			};
 		};
 	};
@@ -145,7 +154,6 @@
 				vdd-supply = <&pb_rst>;
 				status = "okay";
 			};
-
 			piright: ethernet@1 {
 				/* PiBridge Ethernet right */
 				compatible = "micrel,ks8851";


### PR DESCRIPTION
There is no resistor to pull down sniff pin A2. This leads to a false
detection of a device on the left side of the pi-bridge in case that no
devices are connected: in this case a high signal level is read from the
line which is interpreted as an existing device during the pi-bridge
detection procedure.

Fix this by using the internal pull down of the pin controller.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>