### PR TITLE
ci: link action overview with artifacts in PR

### DIFF
--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -14,3 +14,29 @@ jobs:
     with:
       kernelbakery_branch: devel/5.10
       picontrol_branch: devel/revpi-5.10
+  link_artifacts:
+    name: link artifacts in PR
+    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') }}
+    needs: kernelbakery_snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '📦 Your snapshot packages are ready! https://github.com/RevolutionPi/linux/actions/runs/${{github.run_id}}'
+            })
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'snapshot-packages'
+            })


### PR DESCRIPTION
Link to the action overview page with the list of generated snapshot packages after the build is finished.