### PR TITLE
 ci: link action overview with artifacts in PR (kernel 4.19)

### DIFF
--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -16,3 +16,29 @@ jobs:
     with:
       kernelbakery_branch: master
       picontrol_branch: master
+  link_artifacts:
+    name: link artifacts in PR
+    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') }}
+    needs: kernelbakery_snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '📦 Your snapshot packages are ready! https://github.com/RevolutionPi/linux/actions/runs/${{github.run_id}}'
+            })
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'snapshot-packages'
+            })


### PR DESCRIPTION
 Link to the action overview page with the list of generated snapshot packages after the build is finished. Also the snapshot-packages label is removed after the build is finished

Same as in #64 but now for kernel 4.19