### PR TITLE
dts: fix hdmi1 on cm4s

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -206,8 +206,6 @@
 #include "bcm283x-rpi-csi1-4lane.dtsi"
 #include "bcm283x-rpi-i2c0mux_0_28.dtsi"
 
-/delete-node/ &hdmi1;
-
 / {
 	chosen {
 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";

--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -416,6 +416,16 @@
 	};
 };
 
+/* Permanently disable HDMI1 */
+&hdmi1 {
+	compatible = "disabled";
+};
+
+/* Permanently disable DDC1 */
+&ddc1 {
+	compatible = "disabled";
+};
+
 &leds {
 	act_led: led-act {
 		label = "led0";


### PR DESCRIPTION
backport the upstream patches for making vc kms driver usable with CM4s

refs REVPI-1841 and REVPI-1840