### PR TITLE
dts: update dt blobs for cm4s

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-compact-dt-blob-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-compact-dt-blob-overlay.dts
@@ -1439,6 +1439,118 @@
          }; // pin_defines
       }; // pins
 
+      pins_cm4s { // Pi 4 CM4S
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p0 { function = "input"; termination = "pull_up"; }; // RevPi Compact CAMERA_0_SDA_PIN
+            pin@p1 { function = "input"; termination = "pull_up"; }; // RevPi Compact CAMERA_0_SCL_PIN
+            pin@p5 { function = "output"; termination = "no_pulling"; }; // RevPi Compact CAMERA_0_LED
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p21 { function = "output"; termination = "no_pulling"; }; // RevPi Compact CAMERA_0_SHUTDOWN
+            pin@p38 { function = "uart0";  termination = "no_pulling"; }; // RevPi Compact UART0 RTS
+            pin@p39 { function = "output"; termination = "no_pulling"; polarity = "active_low"; startup_state = "inactive"; }; // RevPi Compact UART0 TERM
+            pin@p42 { function = "spi2"; termination = "no_pulling"; drive_strength_mA = < 8 >; }; // RevPi Compact SPI2 CLK
+            pin@p44 { function = "output"; termination = "no_pulling"; polarity = "active_low"; }; // RevPi Compact AIN CS
+            pin@p46 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "absent";
+            };
+            pin_define@EMMC_ENABLE {
+               type = "internal";
+               number = <49>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@BT_ON {
+               type = "absent";
+            };
+            pin_define@WL_ON {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@WL_LPO_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <5>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <21>;
+            };
+         }; // pin_defines
+      }; // pins
+
       pins_pi0 { // Pi zero
          pin_config {
             pin@default {

--- a/arch/arm/boot/dts/overlays/revpi-connect-dt-blob-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-dt-blob-overlay.dts
@@ -1409,6 +1409,88 @@
          }; // pin_defines
       }; // pins
 
+      pins_cm4s { // Pi 4 CM4S
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p4 { function = "output"; termination = "no_pulling"; startup_state = "inactive"; }; // RevPi Connect GPIO Mux
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p39 { function = "spi"; termination = "no_pulling"; drive_strength_mA = < 8 >; }; // RevPi Connect SPI0 CLK
+            pin@p46 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "absent";
+            };
+            pin_define@EMMC_ENABLE {
+               type = "internal";
+               number = <49>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@BT_ON {
+               type = "absent";
+            };
+            pin_define@WL_ON {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@WL_LPO_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+         }; // pin_defines
+      }; // pins
+
       pins_pi0 { // Pi zero
          pin_config {
             pin@default {

--- a/arch/arm/boot/dts/overlays/revpi-core-dt-blob-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-dt-blob-overlay.dts
@@ -1408,6 +1408,87 @@
          }; // pin_defines
       }; // pins
 
+      pins_cm4s { // Pi 4 CM4S
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p39 { function = "spi"; termination = "no_pulling"; drive_strength_mA = < 8 >; }; // RevPi Core SPI0 CLK
+            pin@p46 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "absent";
+            };
+            pin_define@EMMC_ENABLE {
+               type = "internal";
+               number = <49>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@BT_ON {
+               type = "absent";
+            };
+            pin_define@WL_ON {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@WL_LPO_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+         }; // pin_defines
+      }; // pins
+
       pins_pi0 { // Pi zero
          pin_config {
             pin@default {

--- a/arch/arm/boot/dts/overlays/revpi-flat-dt-blob-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-dt-blob-overlay.dts
@@ -1750,6 +1750,91 @@
          }; // pin_defines
       }; // pins
 
+       pins_cm4s { // Pi 4 CM4S
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p17 { function = "uart0";  termination = "no_pulling"; }; // RevPi Flat UART0 RTS
+            pin@p31 { function = "uart1";  termination = "no_pulling"; }; // RevPi Flat UART1 RTS
+            pin@p32 { function = "uart1";  termination = "no_pulling"; }; // RevPi Flat UART1 TX
+            pin@p33 { function = "uart1";  termination = "no_pulling"; }; // RevPi Flat UART1 RX
+            pin@p44 { function = "output"; termination = "no_pulling"; polarity = "active_low"; }; // RevPi Flat AIN CS
+            pin@p46 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "absent";
+            };
+            pin_define@EMMC_ENABLE {
+               type = "internal";
+               number = <49>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@BT_ON {
+               type = "absent";
+            };
+            pin_define@WL_ON {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@WL_LPO_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+         }; // pin_defines
+      }; // pins
+
       pins_pi0 { // Pi zero
          pin_config {
             pin@default {


### PR DESCRIPTION
Add support for CM4s for all four revpi devices, based on latest upstream [dt-blob.dts](https://raw.githubusercontent.com/raspberrypi/firmware/577aef2bc2f8e9dcd6955a85cf0621cc73b29db7/extra/dt-blob.dts) and our configuration of CM3

refs REVPI-1834