### PR TITLE
dts: revpi-core: pull down sniff pin

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -66,6 +66,9 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&sniff_a_pins>;
+
 			spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
@@ -88,6 +91,12 @@
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			sniff_a_pins: pb_sniff_a_pins {
+				/* A2 */
+				brcm,pins     = <28>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+				brcm,pull     = <BCM2835_PUD_DOWN>;
 			};
 		};
 	};


### PR DESCRIPTION
dts: revpi-core: pull down sniff pin

There is no pull-down resistor for the PB_SNIFF 2a (gpio28). So the pin is
floating if no device is connected. During device detection piControl
outputs a HIGH signal for 9ms and then configures the gpio as input again.
The signal will then read as HIGH for some time after this as there
is no pull-down attached. So when piControl actually reads the pin to
determine if any module is connected to the left side it will falsely
detect a device and then start the device configuration procedure. This
results in an error due to the missing response of the falsely detected
device.

Fix this by configuring the internal (weak) pull down of the pin controller
in the dt overlay.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>