### PR TITLE
dts: revpi-*:  correct name of mmc activity node

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
@@ -87,7 +87,7 @@
 					gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 					linux,default-trigger = "a2_red";
 				};
-				act {
+				led-act {
 					status = "disabled";
 				};
 			};

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -64,7 +64,7 @@
 					gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
 					linux,default-trigger = "a3_red";
 				};
-				act {
+				led-act {
 					status = "disabled";
 				};
 			};

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -56,7 +56,7 @@
 					gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 					linux,default-trigger = "a2_red";
 				};
-				act {
+				led-act {
 					status = "disabled";
 				};
 			};

--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -91,7 +91,7 @@
 					gpios = <&expander 9 GPIO_ACTIVE_LOW>;
 					linux,default-trigger = "a5_red";
 				};
-				act {
+				led-act {
 					status = "disabled";
 				};
 			};


### PR DESCRIPTION
With commit fc71d8df5807 the name of the node for the MMC activity LED has
changed from "act" to "led-act". Adjust all revpi overlays to the new name.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>