### PR TITLE
dts: revpi-connect: add node for pibridge device (REVPI-1816)

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -19,6 +19,16 @@
 			compatible = "kunbus,revpi-connect", "brcm,bcm2837",
 				     "brcm,bcm2836";
 
+			pibridge {
+				compatible = "kunbus,pibridge";
+				/* X2DI, X2DO, WDTrigger */
+				connect-gpios = <&gpio 0 GPIO_ACTIVE_HIGH>,
+						<&gpio 1 GPIO_ACTIVE_HIGH>,
+						<&gpio 42 GPIO_ACTIVE_HIGH>;
+				/* Sniff pins 1A and 2A */
+				left-sniff-gpios = <&gpio 43 GPIO_ACTIVE_HIGH>,
+						   <&gpio 29 GPIO_ACTIVE_HIGH>;
+			};
 			/*
 			   The reset of the KSZ8851 used for the pibridge has a
 			   circuit, which keeps it pulled for up to 80ms. To


### PR DESCRIPTION
Add a new node for a kunbus pibridge device that includes a list of the
sniff gpios as well as the gpios X2DI, X2DO and WDTRIGGER.

With this device tree entry the piControl module is able to retrieve the
sniff gpios without having to know which gpio controller is in use.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>