### PR TITLE
arm: dts: overlays: ensure usb is enabled on RevPi

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
@@ -306,6 +306,7 @@
 		target = <&usb>;
 		__overlay__ {
 			dr_mode = "host";
+			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -189,6 +189,8 @@
 	fragment@5 {
 		target = <&usb>;
 		__overlay__ {
+			dr_mode = "host";
+			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -181,6 +181,8 @@
 	fragment@6 {
 		target = <&usb>;
 		__overlay__ {
+			dr_mode = "host";
+			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -284,6 +284,8 @@
 	fragment@7 {
 		target = <&usb>;
 		__overlay__ {
+			dr_mode = "host";
+			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <0>;
 


### PR DESCRIPTION
Ensure that the usb 2.0 controller is enabled on CM1/CM3/CM4s based
RevPi devices. Also ensure that host_mode is active.

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>