### PR TITLE
CI: Fix commit id in package builds

### DIFF
--- a/.github/workflows/merge-packages.yml
+++ b/.github/workflows/merge-packages.yml
@@ -1,0 +1,12 @@
+name: Build
+on:
+  push:
+    branches:
+      - devel/revpi-5.10
+jobs:
+  kernelbakery_snapshot:
+    name: snapshot
+    uses:  RevolutionPi/ci-workflows/.github/workflows/kernel-snapshot.yml@main
+    with:
+      kernelbakery_branch: devel/5.10
+      picontrol_branch: devel/revpi-5.10

--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -1,15 +1,12 @@
 name: Build
 on:
-  push:
-    branches:
-      - devel/revpi-5.10
   pull_request:
     types:
       - labeled
 jobs:
   kernelbakery_snapshot:
     name: snapshot
-    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') || github.event_name == 'push' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages'}}
     uses:  RevolutionPi/ci-workflows/.github/workflows/kernel-snapshot.yml@main
     with:
       kernelbakery_branch: devel/5.10

--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       kernelbakery_branch: devel/5.10
       picontrol_branch: devel/revpi-5.10
+      build_commit: ${{ github.event.pull_request.head.sha }}
   link_artifacts:
     name: link artifacts in PR
     if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') }}


### PR DESCRIPTION
As discussed with @iluminat23 the current commit ids of our snapshot packages do not match HEAD of the PR. This PR will override it the commit it with the latest commit from the PR.