### PR TITLE
arm: dts/revpi-con-can: Remove pincontrol references for can0 [REVPI-1921]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-con-can-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-con-can-overlay.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 /plugin/;
 #include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/bcm2835.h>
 
 /{
 	compatible = "brcm,bcm2837";
@@ -30,6 +31,17 @@
 	};
 
 	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			conbridge_int_pins: conbridge_int_pins {
+				brcm,pins     = <28>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+		};
+	};
+
+	fragment@3 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -107,11 +107,6 @@
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			conbridge_int_pins: conbridge_int_pins {
-				brcm,pins     = <28>;
-				brcm,function = <BCM2835_FSEL_GPIO_IN>;
-				brcm,pull     = <BCM2835_PUD_OFF>;
-			};
 			i2c1 {
 				/* sda scl */
 				brcm,pins     = <44 45>;


### PR DESCRIPTION
Remove pincontrol reference for <&conbridge_int_pins> in order to
restore the con can module functionality, which worked before these
changes. conbridge_int_pins is defined in revpi-connect-overlay.dts and
therefore not exported to the symbols table. This results in the
following error when the overlay is loaded:

OF: resolver: node label 'conbridge_int_pins' not found in live
devicetree symbols table

This partialy reverts commit 164a3d73bae2a

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>