### PR TITLE
Add the device tree overlay for Core SE [REVPI-1965]

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -173,6 +173,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	revpi-flat-dt-blob.dtbo \
 	revpi-core.dtbo \
 	revpi-core-dt-blob.dtbo \
+	revpi-core-se-2022.dtbo \
 	cmio-jtag-dt-blob.dtbo \
 	rotary-encoder.dtbo \
 	rpi-backlight.dtbo \

--- a/arch/arm/boot/dts/overlays/revpi-core-se-2022-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-se-2022-overlay.dts
@@ -1,0 +1,40 @@
+/*
+ * Device tree overlay for Revolution Pi by KUNBUS
+ *
+ * RevPi Core SE (2022)
+ */
+
+ #include "revpi-core-s-2022-overlay.dts"
+
+/{
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			compatible = "kunbus,revpi-core-se-2022",
+				     "kunbus,revpi-core", "brcm,bcm2711";
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			/delete-node/ pileft_pins;
+			/delete-node/ piright_pins;
+		};
+	};
+
+	fragment@8 {
+		target = <&spi0>;
+		__overlay__ {
+			/delete-node/ ethernet@0;
+			/delete-node/ ethernet@1;
+		};
+	};
+
+	__overrides__ {
+		/delete-property/ pileft_mac_hi;
+		/delete-property/ pileft_mac_lo;
+		/delete-property/ piright_mac_hi;
+		/delete-property/ piright_mac_lo;
+	};
+};


### PR DESCRIPTION
The Core3 SE comes without ethernet interface on pibridge by
comparing with Core 3, so based on the device tree overlay of
Core 3 the following related configurations can be removed:

 * Configuration of the regulator_pbrst
 * Configuration of spi pins for ksz8851, and pileft, piright

Signed-off-by: Zhi Han <z.han@kunbus.com>