### PR TITLE
Fix pinmux for Core/Connect [REVPI-1982]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -120,10 +120,10 @@
 						 BCM2835_FSEL_ALT0
 						 BCM2835_FSEL_ALT3
 						 BCM2835_FSEL_GPIO_OUT>;
-				brcm,pull     = <BCM2835_PUD_DOWN
-						 BCM2835_PUD_DOWN
-						 BCM2835_PUD_DOWN
-						 BCM2835_PUD_UP>;
+				brcm,pull     = <BCM2835_PUD_OFF
+						 BCM2835_PUD_UP
+						 BCM2835_PUD_OFF
+						 BCM2835_PUD_OFF>;
 			};
 		};
 	};
@@ -230,9 +230,10 @@
 	fragment@6 {
 		target = <&uart0>;
 		__overlay__ {
-			linux,rs485-enabled-at-boot-time;
 			pinctrl-names = "default";
 			pinctrl-0 = <&rs485_pins>;
+			linux,rs485-enabled-at-boot-time;
+			status = "okay";
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -48,6 +48,8 @@
 
 			leds {
 				compatible = "gpio-leds";
+				pinctrl-names = "default";
+				pinctrl-0 = <&led_pins>;
 				power_red {
 					gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
 					linux,default-trigger = "power_red";
@@ -86,13 +88,13 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
-			spi0_pins {
+			spi0_pins: spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
 				brcm,function = <BCM2835_FSEL_ALT0>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			spi0_cs_pins {
+			spi0_cs_pins: spi0_cs_pins {
 				brcm,pins     = <36 35>;
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
@@ -107,10 +109,16 @@
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			i2c1 {
+			i2c1_pins: i2c1_pins {
 				/* sda scl */
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			led_pins: led_pins {
+				/* pwr_red a1_green a1_red a2_green a2_red a3_green a3_red */
+				brcm,pins     = <16 30 6 32 33 2 3>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			rs485_pins: rs485_pins {
@@ -131,6 +139,8 @@
 	fragment@2 {
 		target = <&i2c1>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c1_pins>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
@@ -159,6 +169,8 @@
 	fragment@4 {
 		target = <&spi0>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
 			cs-gpios = <&gpio 36 GPIO_ACTIVE_LOW>,
 				   <&gpio 35 GPIO_ACTIVE_LOW>;
 			#address-cells = <1>;

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -20,6 +20,9 @@
 				     "brcm,bcm2836";
 
 			pibridge {
+				pinctrl-names = "default";
+				pinctrl-0 = <&sniff_pins &connect_pins>;
+
 				compatible = "kunbus,pibridge";
 				/* X2DI, X2DO, WDTrigger */
 				connect-gpios = <&gpio 0 GPIO_ACTIVE_HIGH>,
@@ -113,6 +116,23 @@
 				/* sda scl */
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			sniff_pins: sniff_pins {
+				/* 1A 2A
+				 * Note: In the schematics they are wrongly named
+				 * PB_SNIFF1b and PB_SNIFF2b
+				 */
+				brcm,pins     = <43 29>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			connect_pins: connect_pins {
+				/* X2DI, X2DO, WDTrigger */
+				brcm,pins     = <0 1 42>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN
+						 BCM2835_FSEL_GPIO_OUT
+						 BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			led_pins: led_pins {

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -21,6 +21,9 @@
 
 			pibridge {
 				compatible = "kunbus,pibridge";
+				pinctrl-names = "default";
+				pinctrl-0 = <&sniff_pins>;
+
 				/* Sniff pins 1A and 2A */
 				left-sniff-gpios = <&gpio 42 GPIO_ACTIVE_HIGH>,
 						   <&gpio 28 GPIO_ACTIVE_HIGH>;
@@ -77,9 +80,6 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
-			pinctrl-names = "default";
-			pinctrl-0 = <&sniff_a_pins>;
-
 			spi0_pins: spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
@@ -103,11 +103,14 @@
 				brcm,function = <BCM2835_FSEL_ALT2>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			sniff_a_pins: pb_sniff_a_pins {
-				/* A2 */
-				brcm,pins     = <28>;
+			sniff_pins: sniff_pins {
+				/* 1A 2A 1B 2B */
+				brcm,pins     = <42 28 43 29>;
 				brcm,function = <BCM2835_FSEL_GPIO_IN>;
-				brcm,pull     = <BCM2835_PUD_DOWN>;
+				brcm,pull     = <BCM2835_PUD_OFF
+						 BCM2835_PUD_DOWN
+						 BCM2835_PUD_OFF
+						 BCM2835_PUD_OFF>;
 			};
 			rs485_pins: rs485_pins {
 				/* tx rx rts term */

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -109,6 +109,19 @@
 				brcm,function = <BCM2835_FSEL_GPIO_IN>;
 				brcm,pull     = <BCM2835_PUD_DOWN>;
 			};
+			rs485_pins: rs485_pins {
+				/* tx rx rts term */
+				brcm,pins     = <14 15 17 41>;
+				brcm,function = <BCM2835_FSEL_ALT0
+						 BCM2835_FSEL_ALT0
+						 BCM2835_FSEL_ALT3
+						 BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF
+						 BCM2835_PUD_UP
+						 BCM2835_PUD_OFF
+						 BCM2835_PUD_OFF>;
+
+			};
 		};
 	};
 
@@ -199,6 +212,16 @@
 					reg = <1>;
 				};
 			};
+		};
+	};
+
+	fragment@7 {
+		target = <&uart0>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rs485_pins>;
+			linux,rs485-enabled-at-boot-time;
+			status = "okay";
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -50,6 +50,9 @@
 
 			leds {
 				compatible = "gpio-leds";
+				pinctrl-names = "default";
+				pinctrl-0 = <&led_pins>;
+
 				power_red {
 					gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
 					linux,default-trigger = "power_red";
@@ -111,6 +114,12 @@
 						 BCM2835_PUD_DOWN
 						 BCM2835_PUD_OFF
 						 BCM2835_PUD_OFF>;
+			};
+			led_pins: led_pins {
+				/* pwr_red a1_green a1_red a2_green a2_red */
+				brcm,pins     = <16 30 6 32 33>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			rs485_pins: rs485_pins {
 				/* tx rx rts term */

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -80,13 +80,13 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&sniff_a_pins>;
 
-			spi0_pins {
+			spi0_pins: spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
 				brcm,function = <BCM2835_FSEL_ALT0>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			spi0_cs_pins {
+			spi0_cs_pins: spi0_cs_pins {
 				brcm,pins     = <36 35>;
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
@@ -97,7 +97,7 @@
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			i2c1 {
+			i2c1_pins: i2c1_pins {
 				/* sda scl */
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
@@ -115,6 +115,8 @@
 	fragment@2 {
 		target = <&i2c1>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c1_pins>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
@@ -150,6 +152,8 @@
 	fragment@5 {
 		target = <&spi0>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_pins>, <&spi0_cs_pins>;
 			cs-gpios = <&gpio 36 GPIO_ACTIVE_LOW>,
 				   <&gpio 35 GPIO_ACTIVE_LOW>;
 			#address-cells = <1>;


### PR DESCRIPTION
There are multiple pinmuxes not assigned and some are missing completely.

Add a uart0 node to the core overlay, to use the RTS signal. This will be relevant for the core/connect redesign. For the current versions it doesn't hurt as the pins are not connected.