### PR TITLE
Add device tree overlay for Connect SE [REVPI-2026]

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -168,6 +168,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	revpi-compact-dt-blob.dtbo \
 	revpi-connect.dtbo \
 	revpi-connect-dt-blob.dtbo \
+	revpi-connect-se.dtbo \
+	revpi-connect-se-dt-blob.dtbo \
 	revpi-con-can.dtbo \
 	revpi-flat.dtbo \
 	revpi-flat-dt-blob.dtbo \

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -120,10 +120,10 @@
 						 BCM2835_FSEL_ALT0
 						 BCM2835_FSEL_ALT3
 						 BCM2835_FSEL_GPIO_OUT>;
-				brcm,pull     = <BCM2835_PUD_DOWN
-						 BCM2835_PUD_DOWN
-						 BCM2835_PUD_DOWN
-						 BCM2835_PUD_UP>;
+				brcm,pull     = <BCM2835_PUD_OFF
+						 BCM2835_PUD_UP
+						 BCM2835_PUD_OFF
+						 BCM2835_PUD_OFF>;
 			};
 		};
 	};
@@ -230,9 +230,10 @@
 	fragment@6 {
 		target = <&uart0>;
 		__overlay__ {
-			linux,rs485-enabled-at-boot-time;
 			pinctrl-names = "default";
 			pinctrl-0 = <&rs485_pins>;
+			linux,rs485-enabled-at-boot-time;
+			status = "okay";
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -48,6 +48,8 @@
 
 			leds {
 				compatible = "gpio-leds";
+				pinctrl-names = "default";
+				pinctrl-0 = <&led_pins>;
 				power_red {
 					gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
 					linux,default-trigger = "power_red";
@@ -86,13 +88,13 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
-			spi0_pins {
+			spi0_pins: spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
 				brcm,function = <BCM2835_FSEL_ALT0>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			spi0_cs_pins {
+			spi0_cs_pins: spi0_cs_pins {
 				brcm,pins     = <36 35>;
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
@@ -107,10 +109,16 @@
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			i2c1 {
+			i2c1_pins: i2c1_pins {
 				/* sda scl */
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			led_pins: led_pins {
+				/* pwr_red a1_green a1_red a2_green a2_red a3_green a3_red */
+				brcm,pins     = <16 30 6 32 33 2 3>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			rs485_pins: rs485_pins {
@@ -131,6 +139,8 @@
 	fragment@2 {
 		target = <&i2c1>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c1_pins>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
@@ -159,6 +169,8 @@
 	fragment@4 {
 		target = <&spi0>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
 			cs-gpios = <&gpio 36 GPIO_ACTIVE_LOW>,
 				   <&gpio 35 GPIO_ACTIVE_LOW>;
 			#address-cells = <1>;

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -88,6 +88,9 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&sniff_pins &conbridge_pins>;
+
 			spi0_pins: spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
@@ -113,6 +116,23 @@
 				/* sda scl */
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			sniff_pins: sniff_pins {
+				/* 1A 2A
+				 * Note: In the schematics they are wrongly named
+				 * PB_SNIFF1b and PB_SNIFF2b
+				 */
+				brcm,pins     = <43 29>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			conbridge_pins: conbridge_pins {
+				/* X2DI, X2DO, WDTrigger */
+				brcm,pins     = <0 1 42>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN
+						 BCM2835_FSEL_GPIO_OUT
+						 BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			led_pins: led_pins {

--- a/arch/arm/boot/dts/overlays/revpi-connect-se-dt-blob-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-se-dt-blob-overlay.dts
@@ -1,0 +1,1792 @@
+/dts-v1/;
+
+/ {
+   videocore {
+      pins_rev1 {
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p2  { function = "i2c1";   termination = "pull_up"; }; // I2C 1 SDA
+            pin@p3  { function = "i2c1";   termination = "pull_up"; }; // I2C 1 SCL
+            pin@p5  { function = "output"; termination = "pull_down"; }; // CAM_LED
+            pin@p6  { function = "output"; termination = "pull_down";  startup_state = "active"; }; // LAN_RUN
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p16 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+            pin@p27 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p45 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p46 { function = "input";  termination = "no_pulling";    }; // Hotplug
+            pin@p47 { function = "input";  termination = "no_pulling";    }; // SD_CARD_DETECT
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <2>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <3>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <27>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <5>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <16>;
+            };
+            pin_define@LAN_RUN {
+               type = "internal";
+               number = <6>;
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@SAFE_MODE {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <1>;
+            };
+         }; // pin_defines
+      }; // pins_rev1
+
+      pins_rev2 {
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p0  { function = "i2c0";   termination = "pull_up"; }; // I2C 0 SDA
+            pin@p1  { function = "i2c0";   termination = "pull_up"; }; // I2C 0 SCL
+            pin@p5  { function = "output"; termination = "pull_down"; }; // CAM_LED
+            pin@p6  { function = "output"; termination = "pull_down"; startup_state = "active"; }; // LAN NRESET
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p16 { function = "output"; termination = "pull_up"; polarity = "active_low"; }; // activity LED
+            pin@p21 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p45 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p46 { function = "input";  termination = "no_pulling";    }; // Hotplug
+            pin@p47 { function = "input";  termination = "no_pulling";    }; // SD_CARD_DETECT
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <21>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <5>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <16>;
+            };
+            pin_define@LAN_RUN {
+               type = "internal";
+               number = <6>;
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@SAFE_MODE {
+               type = "internal";
+               number = <3>;
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <2>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <3>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_bplus1 { // Pi 1 Model B+ rev 1.1
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p28 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p29 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p31 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Power low
+            pin@p32 { function = "output"; termination = "pull_down"; }; // Camera LED
+            pin@p35 { function = "output"; termination = "pull_down"; startup_state = "active"; }; // LAN_RUN
+            pin@p38 { function = "output"; termination = "no_pulling";    }; // USB current limit (0=600mA, 1=1200mA)
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p41 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            pin@p44 { function = "gp_clk"; termination = "pull_down"; }; // ETH_CLK - Ethernet 25MHz output
+            pin@p45 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p46 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p47 { function = "output"; termination = "pull_down"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <32>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "internal";
+               number = <31>;
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "internal";
+               number = <35>;
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "internal";
+               number = <38>;
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@SAFE_MODE {
+               type = "internal";
+               number = <3>;
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <29>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_bplus2 { // Pi 1 Model B+ rev 1.2
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p28 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p29 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p31 { function = "output"; termination = "pull_down";  startup_state = "active"; }; // LAN_RUN
+            pin@p32 { function = "output"; termination = "pull_down"; }; // Camera LED
+            pin@p35 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Power low
+            pin@p38 { function = "output"; termination = "no_pulling";    }; // USB current limit (0=600mA, 1=1200mA)
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p41 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            pin@p44 { function = "gp_clk"; termination = "pull_down"; }; // ETH_CLK - Ethernet 25MHz output
+            pin@p45 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p46 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p47 { function = "output"; termination = "pull_down"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <32>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "internal";
+               number = <35>;
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "internal";
+               number = <31>;
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "internal";
+               number = <38>;
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@SAFE_MODE {
+               type = "internal";
+               number = <3>;
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <29>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_aplus {
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p28 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p29 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p32 { function = "output"; termination = "pull_down"; }; // Camera LED
+            pin@p35 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Power low
+            pin@p38 { function = "output"; termination = "no_pulling";    }; // USB current limit (0=600mA, 1=1200mA)
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p41 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            pin@p45 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p46 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p47 { function = "output"; termination = "pull_down"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <32>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "internal";
+               number = <35>;
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "internal";
+               number = <38>;
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@SAFE_MODE {
+               type = "internal";
+               number = <3>;
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <29>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_2b1 { // Pi 2 Model B rev 1.0
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p28 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA / SMPS_SDA
+            pin@p29 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL / SMPS_SCL
+            pin@p31 { function = "output"; termination = "pull_down";  startup_state = "active"; }; // LAN_RUN
+            pin@p32 { function = "output"; termination = "pull_down"; }; // Camera LED
+            pin@p35 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Power low
+            pin@p38 { function = "output"; termination = "no_pulling";    }; // USB current limit (0=600mA, 1=1200mA)
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p41 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            pin@p44 { function = "gp_clk"; termination = "pull_down"; }; // ETH_CLK - Ethernet 25MHz output
+            pin@p45 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p46 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p47 { function = "output"; termination = "pull_down"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <32>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "internal";
+               number = <35>;
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "internal";
+               number = <31>;
+            };
+            pin_define@SMPS_SDA {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@SMPS_SCL {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@ETH_CLK {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "internal";
+               number = <38>;
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@SAFE_MODE {
+               type = "internal";
+               number = <3>;
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <29>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_2b2 { // Pi 2 Model B rev 1.1
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p28 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p29 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p31 { function = "output"; termination = "pull_down";  startup_state = "active"; }; // LAN_RUN
+            pin@p32 { function = "output"; termination = "pull_down"; }; // Camera LED
+            pin@p35 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Power low
+            pin@p38 { function = "output"; termination = "no_pulling";    }; // USB current limit (0=600mA, 1=1200mA)
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p41 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            // Communicate with the SMPS by "bit-bashing" the I2C protocol on GPIOs 42 and 43
+            pin@p42 { function = "output"; termination = "pull_up";    }; // SMPS_SCL
+            pin@p43 { function = "input";  termination = "no_pulling";    }; // SMPS_SDA
+            pin@p44 { function = "gp_clk"; termination = "pull_down"; }; // ETH_CLK - Ethernet 25MHz output
+            pin@p45 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p46 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p47 { function = "output"; termination = "pull_down"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <32>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "internal";
+               number = <35>;
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "internal";
+               number = <31>;
+            };
+            pin_define@SMPS_SDA {
+               type = "internal";
+               number = <43>;
+            };
+            pin_define@SMPS_SCL {
+               type = "internal";
+               number = <42>;
+            };
+            pin_define@ETH_CLK {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "internal";
+               number = <38>;
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@SAFE_MODE {
+               type = "internal";
+               number = <3>;
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <29>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_3b1 { // Pi 3 Model B rev 1.0
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up";    drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p34 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p35 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p36 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p37 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p38 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p39 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p41 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p42 { function = "gp_clk"; termination = "pull_down"; }; // ETH_CLK - Ethernet 25MHz output
+            pin@p43 { function = "gp_clk"; termination = "pull_down"; }; // WIFI_CLK - Wifi 32kHz output
+            pin@p44 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p45 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p47 { function = "output"; termination = "pull_down"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+            pin@p128 { function = "output"; termination = "no_pulling"; }; // BT_ON
+            pin@p129 { function = "output"; termination = "no_pulling"; }; // WL_ON
+            pin@p130 { function = "output"; termination = "no_pulling"; }; // Status LED
+            pin@p131 { function = "output"; termination = "no_pulling";  startup_state = "active"; }; // LAN_RUN
+            pin@p132 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p133 { function = "output"; termination = "no_pulling"; }; // Camera LED
+            pin@p134 { function = "output"; termination = "no_pulling"; }; // Camera shutdown
+            pin@p135 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Power low
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "external";
+               number = <4>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "external";
+               number = <6>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "external";
+               number = <5>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "external";
+               number = <7>;
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "external";
+               number = <3>;
+            };
+            pin_define@LAN_RUN_BOOT {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@BT_ON {
+               type = "external";
+               number = <0>;
+            };
+            pin_define@WL_ON {
+               type = "external";
+               number = <1>;
+            };
+            pin_define@SMPS_SDA {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@SMPS_SCL {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@ETH_CLK {
+               type = "internal";
+               number = <42>;
+            };
+            pin_define@WL_LPO_CLK {
+               type = "internal";
+               number = <43>;
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <45>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_3b2 { // Pi 3 Model B rev 1.2
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up";    drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p34 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p35 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p36 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p37 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p38 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p39 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p40 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Right audio
+            pin@p41 { function = "pwm";    termination = "no_pulling"; drive_strength_mA = < 16 >; }; // Left audio
+            pin@p42 { function = "gp_clk"; termination = "pull_down"; }; // ETH_CLK - Ethernet 25MHz output
+            pin@p43 { function = "gp_clk"; termination = "pull_down"; }; // WIFI_CLK - Wifi 32kHz output
+            pin@p44 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p45 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p46 { function = "input";   termination = "pull_up";    }; // SMPS_SCL
+            pin@p47 { function = "input";   termination = "pull_up";    }; // SMPS_SDA
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+            pin@p128 { function = "output"; termination = "no_pulling"; }; // BT_ON
+            pin@p129 { function = "output"; termination = "no_pulling"; }; // WL_ON
+            pin@p130 { function = "output"; termination = "no_pulling"; }; // ACT_LED
+            pin@p131 { function = "output"; termination = "no_pulling"; startup_state = "active"; }; // LAN_RUN
+            pin@p132 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p133 { function = "output"; termination = "no_pulling"; }; // Camera shutdown
+            pin@p134 { function = "output"; termination = "no_pulling"; }; // Camera LED
+            pin@p135 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Power low
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "external";
+               number = <4>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "external";
+               number = <5>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "external";
+               number = <6>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "external";
+               number = <7>;
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "external";
+               number = <2>;
+            };
+            pin_define@LAN_RUN {
+               type = "external";
+               number = <3>;
+            };
+            pin_define@LAN_RUN_BOOT {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@BT_ON {
+               type = "external";
+               number = <0>;
+            };
+            pin_define@WL_ON {
+               type = "external";
+               number = <1>;
+            };
+            pin_define@SMPS_SDA {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@SMPS_SCL {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@ETH_CLK {
+               type = "internal";
+               number = <42>;
+            };
+            pin_define@WL_LPO_CLK {
+               type = "internal";
+               number = <43>;
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@PWMR {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@DISPLAY_SDA {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@DISPLAY_SCL {
+               type = "internal";
+               number = <45>;
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_cm3 { // Pi 3 CM3
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p46 { function = "input";   termination = "pull_up";    }; // SMPS_SCL
+            pin@p47 { function = "input";   termination = "pull_up";    }; // SMPS_SDA
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+            pin@p128 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p129 { function = "output"; termination = "no_pulling"; polarity = "active_low"; }; // EMMC_ENABLE_N
+            pin@p4 { function = "output"; termination = "no_pulling"; startup_state = "inactive"; }; // RevPi Connect GPIO Mux
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "external";
+               number = <0>;
+            };
+            pin_define@EMMC_ENABLE {
+               type = "external";
+               number = <1>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "absent";
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@SMPS_SCL {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@WL_LPO_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_cm4s { // Pi 4 CM4S
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p4 { function = "output"; termination = "no_pulling"; startup_state = "inactive"; }; // RevPi Connect GPIO Mux
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p46 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "absent";
+            };
+            pin_define@EMMC_ENABLE {
+               type = "internal";
+               number = <49>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@BT_ON {
+               type = "absent";
+            };
+            pin_define@WL_ON {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@WL_LPO_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "absent";
+            };
+            pin_define@ID_SCL {
+               type = "absent";
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_pi0 { // Pi zero
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p28 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p29 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p32 { function = "output"; termination = "pull_down"; }; // Camera LED
+            pin@p41 { function = "output"; termination = "no_pulling";    }; // Camera shutdown
+            pin@p46 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p47 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <32>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "absent";
+            };
+            pin_define@DISPLAY_SDA {
+               type = "absent";
+            };
+            pin_define@DISPLAY_SCL {
+               type = "absent";
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_pi0w { // Pi zero W
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; drive_strength_mA = < 8 >; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; drive_strength_mA = < 8 >; }; // RX uart0
+            pin@p28 { function = "input";   termination = "pull_up";    }; // I2C 0 SDA
+            pin@p29 { function = "input";   termination = "pull_up";    }; // I2C 0 SCL
+            pin@p34 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p35 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p36 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p37 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p38 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p39 { function = "input";  termination = "pull_up";    drive_strength_mA = < 8 >; };
+            pin@p40 { function = "output"; termination = "pull_down"; }; // Camera LED
+            pin@p41 { function = "output"; termination = "no_pulling"; }; // WL_ON
+            pin@p43 { function = "gp_clk"; termination = "pull_down"; }; // WIFI_CLK - Wifi 32kHz output
+            pin@p44 { function = "output"; termination = "no_pulling"; }; // Camera shutdown
+            pin@p45 { function = "output"; termination = "no_pulling"; }; // BT_ON
+            pin@p46 { function = "input";  termination = "no_pulling"; polarity = "active_low"; }; // Hotplug
+            pin@p47 { function = "output"; termination = "pull_up"; polarity="active_low"; }; // activity LED
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@HDMI_CONTROL_ATTACHED {
+               type = "internal";
+               number = <46>;
+            };
+            pin_define@NUM_CAMERAS {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_I2C_PORT {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@CAMERA_0_SDA_PIN {
+               type = "internal";
+               number = <28>;
+            };
+            pin_define@CAMERA_0_SCL_PIN {
+               type = "internal";
+               number = <29>;
+            };
+            pin_define@CAMERA_0_SHUTDOWN {
+               type = "internal";
+               number = <44>;
+            };
+            pin_define@CAMERA_0_UNICAM_PORT {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@CAMERA_0_LED {
+               type = "internal";
+               number = <40>;
+            };
+            pin_define@FLASH_0_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_0_INDICATOR {
+               type = "absent";
+            };
+            pin_define@FLASH_1_ENABLE {
+               type = "absent";
+            };
+            pin_define@FLASH_1_INDICATOR {
+               type = "absent";
+            };
+            pin_define@POWER_LOW {
+               type = "absent";
+            };
+            pin_define@LEDS_DISK_ACTIVITY {
+               type = "internal";
+               number = <47>;
+            };
+            pin_define@LAN_RUN {
+               type = "absent";
+            };
+            pin_define@BT_ON {
+               type = "internal";
+               number = <45>;
+            };
+            pin_define@WL_ON {
+               type = "internal";
+               number = <41>;
+            };
+            pin_define@WL_LPO_CLK {
+               type = "internal";
+               number = <43>;
+            };
+            pin_define@SMPS_SDA {
+               type = "absent";
+            };
+            pin_define@SMPS_SCL {
+               type = "absent";
+            };
+            pin_define@ETH_CLK {
+               type = "absent";
+            };
+            pin_define@USB_LIMIT_1A2 {
+               type = "absent";
+            };
+            pin_define@SIO_1V8_SEL {
+               type = "absent";
+            };
+            pin_define@PWML {
+               type = "absent";
+            };
+            pin_define@PWMR {
+               type = "absent";
+            };
+            pin_define@SAFE_MODE {
+               type = "absent";
+            };
+            pin_define@SD_CARD_DETECT {
+               type = "absent";
+            };
+            pin_define@ID_SDA {
+               type = "internal";
+               number = <0>;
+            };
+            pin_define@ID_SCL {
+               type = "internal";
+               number = <1>;
+            };
+            pin_define@DISPLAY_I2C_PORT {
+               type = "absent";
+            };
+            pin_define@DISPLAY_SDA {
+               type = "absent";
+            };
+            pin_define@DISPLAY_SCL {
+               type = "absent";
+            };
+         }; // pin_defines
+      }; // pins
+
+      pins_cm {
+         pin_config {
+            pin@default {
+               polarity = "active_high";
+               termination = "pull_down";
+               startup_state = "inactive";
+               function = "input";
+            }; // pin
+            pin@p14 { function = "uart0";  termination = "no_pulling"; }; // TX uart0
+            pin@p15 { function = "uart0";  termination = "pull_up"; }; // RX uart0
+            pin@p47 { function = "output"; termination = "no_pulling"; polarity = "active_low"; }; // EMMC_ENABLE_N
+            pin@p48 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CLK
+            pin@p49 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD CMD
+            pin@p50 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D0
+            pin@p51 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D1
+            pin@p52 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D2
+            pin@p53 { function = "sdcard"; termination = "pull_up";    drive_strength_mA = < 8 >; }; // SD D3
+         }; // pin_config
+
+         pin_defines {
+            pin_define@EMMC_ENABLE {
+               type = "internal";
+               number = <47>;
+            };
+         }; // pin_defines
+      }; // pins_cm
+   };
+};

--- a/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
@@ -1,0 +1,221 @@
+/*
+ * Device tree overlay for Revolution Pi by KUNBUS
+ *
+ * RevPi Connect
+ */
+
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/bcm2835.h>
+
+/{
+	compatible = "brcm,bcm2837";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			compatible = "kunbus,revpi-connect", "brcm,bcm2837",
+				     "brcm,bcm2836";
+
+			pibridge {
+				compatible = "kunbus,pibridge";
+				/* X2DI, X2DO, WDTrigger */
+				connect-gpios = <&gpio 0 GPIO_ACTIVE_HIGH>,
+						<&gpio 1 GPIO_ACTIVE_HIGH>,
+						<&gpio 42 GPIO_ACTIVE_HIGH>;
+				/* Sniff pins 1A and 2A */
+				left-sniff-gpios = <&gpio 43 GPIO_ACTIVE_HIGH>,
+						   <&gpio 29 GPIO_ACTIVE_HIGH>;
+			};
+
+			leds {
+				compatible = "gpio-leds";
+				pinctrl-names = "default";
+				pinctrl-0 = <&led_pins>;
+				power_red {
+					gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "power_red";
+				};
+				a1_green {
+					gpios = <&gpio 30 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "a1_green";
+				};
+				a1_red {
+					gpios = <&gpio  6 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "a1_red";
+				};
+				a2_green {
+					gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "a2_green";
+				};
+				a2_red {
+					gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "a2_red";
+				};
+				a3_green {
+					gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "a3_green";
+				};
+				a3_red {
+					gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "a3_red";
+				};
+				led-act {
+					status = "disabled";
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&sniff_pins &conbridge_pins>;
+
+			i2c1_pins: i2c1_pins {
+				/* sda scl */
+				brcm,pins     = <44 45>;
+				brcm,function = <BCM2835_FSEL_ALT2>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			sniff_pins: sniff_pins {
+				/* 1A 2A
+				 * Note: In the schematics they are wrongly named
+				 * PB_SNIFF1b and PB_SNIFF2b
+				 */
+				brcm,pins     = <43 29>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			conbridge_pins: conbridge_pins {
+				/* X2DI, X2DO, WDTrigger */
+				brcm,pins     = <0 1 42>;
+				brcm,function = <BCM2835_FSEL_GPIO_IN
+						 BCM2835_FSEL_GPIO_OUT
+						 BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			led_pins: led_pins {
+				/* pwr_red a1_green a1_red a2_green a2_red a3_green a3_red */
+				brcm,pins     = <16 30 6 32 33 2 3>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			rs485_pins: rs485_pins {
+				/* tx rx rts term */
+				brcm,pins     = <14 15 17 41>;
+				brcm,function = <BCM2835_FSEL_ALT0
+						 BCM2835_FSEL_ALT0
+						 BCM2835_FSEL_ALT3
+						 BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF
+						 BCM2835_PUD_UP
+						 BCM2835_PUD_OFF
+						 BCM2835_PUD_OFF>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c1_pins>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			rtc@51 {
+				compatible = "nxp,pcf2129";
+				reg = <0x51>;
+				status = "okay";
+			};
+
+			crypto@60 {
+				compatible = "atmel,atecc508a";
+				reg = <0x60>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&usb>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			hub@1 {
+				/* SMSC LAN9514 */
+				compatible = "usb424,9514";
+				reg = <1>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				eth0: ethernet@1 {
+					compatible = "usb424,ec00";
+					reg = <1>;
+				};
+
+				hub@5 {
+					/* SMSC LAN9512 */
+					compatible = "usb424,9512";
+					reg = <5>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					eth1: ethernet@1 {
+						compatible = "usb424,ec00";
+						reg = <1>;
+					};
+
+					uart@2 {
+						/* FTDI FT232R (front) */
+						compatible = "usb403,6001";
+						reg = <2>;
+					};
+
+					uart@3 {
+						/* FTDI FT232R (conbridge) */
+						compatible = "usb403,6001";
+						reg = <3>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&uart0>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rs485_pins>;
+			linux,rs485-enabled-at-boot-time;
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		eth0_mac_hi = <&eth0>,"local-mac-address:0";
+		eth0_mac_lo = <&eth0>,"local-mac-address;4";
+		eth1_mac_hi = <&eth1>,"local-mac-address:0";
+		eth1_mac_lo = <&eth1>,"local-mac-address;4";
+	};
+};

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -109,6 +109,19 @@
 				brcm,function = <BCM2835_FSEL_GPIO_IN>;
 				brcm,pull     = <BCM2835_PUD_DOWN>;
 			};
+			rs485_pins: rs485_pins {
+				/* tx rx rts term */
+				brcm,pins     = <14 15 17 41>;
+				brcm,function = <BCM2835_FSEL_ALT0
+						 BCM2835_FSEL_ALT0
+						 BCM2835_FSEL_ALT3
+						 BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF
+						 BCM2835_PUD_UP
+						 BCM2835_PUD_OFF
+						 BCM2835_PUD_OFF>;
+
+			};
 		};
 	};
 
@@ -199,6 +212,16 @@
 					reg = <1>;
 				};
 			};
+		};
+	};
+
+	fragment@7 {
+		target = <&uart0>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rs485_pins>;
+			linux,rs485-enabled-at-boot-time;
+			status = "okay";
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -80,13 +80,13 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&sniff_a_pins>;
 
-			spi0_pins {
+			spi0_pins: spi0_pins {
 				/* miso mosi clock */
 				brcm,pins     = <37 38 39>;
 				brcm,function = <BCM2835_FSEL_ALT0>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			spi0_cs_pins {
+			spi0_cs_pins: spi0_cs_pins {
 				brcm,pins     = <36 35>;
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
@@ -97,7 +97,7 @@
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			i2c1 {
+			i2c1_pins: i2c1_pins {
 				/* sda scl */
 				brcm,pins     = <44 45>;
 				brcm,function = <BCM2835_FSEL_ALT2>;
@@ -115,6 +115,8 @@
 	fragment@2 {
 		target = <&i2c1>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c1_pins>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
@@ -150,6 +152,8 @@
 	fragment@5 {
 		target = <&spi0>;
 		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_pins>, <&spi0_cs_pins>;
 			cs-gpios = <&gpio 36 GPIO_ACTIVE_LOW>,
 				   <&gpio 35 GPIO_ACTIVE_LOW>;
 			#address-cells = <1>;

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -78,7 +78,7 @@
 		target = <&gpio>;
 		__overlay__ {
 			pinctrl-names = "default";
-			pinctrl-0 = <&sniff_a_pins>;
+			pinctrl-0 = <&sniff_pins>;
 
 			spi0_pins: spi0_pins {
 				/* miso mosi clock */
@@ -103,11 +103,14 @@
 				brcm,function = <BCM2835_FSEL_ALT2>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
-			sniff_a_pins: pb_sniff_a_pins {
-				/* A2 */
-				brcm,pins     = <28>;
+			sniff_pins: pb_sniff_pins {
+				/* 1A 2A 1B 2B */
+				brcm,pins     = <42 28 43 29>;
 				brcm,function = <BCM2835_FSEL_GPIO_IN>;
-				brcm,pull     = <BCM2835_PUD_DOWN>;
+				brcm,pull     = <BCM2835_PUD_OFF
+						 BCM2835_PUD_DOWN
+						 BCM2835_PUD_OFF
+						 BCM2835_PUD_OFF>;
 			};
 			rs485_pins: rs485_pins {
 				/* tx rx rts term */

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -47,6 +47,9 @@
 
 			leds {
 				compatible = "gpio-leds";
+				pinctrl-names = "default";
+				pinctrl-0 = <&led_pins>;
+
 				power_red {
 					gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
 					linux,default-trigger = "power_red";
@@ -111,6 +114,12 @@
 						 BCM2835_PUD_DOWN
 						 BCM2835_PUD_OFF
 						 BCM2835_PUD_OFF>;
+			};
+			led_pins: led_pins {
+				/* pwr_red a1_green a1_red a2_green a2_red */
+				brcm,pins     = <16 30 6 32 33>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			rs485_pins: rs485_pins {
 				/* tx rx rts term */


### PR DESCRIPTION
The Connect SE comes without ethernet interface on pibridge by
comparing with Connect, so based on the device tree overlay of
Connect the following related configurations can be removed:

 * Configuration of the regulator_pbrst
 * Configuration of spi pins for ksz8851, and pileft