### PR TITLE
Add device tree overlay for Connect SE [REVPI-2206]

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -168,6 +168,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	revpi-compact-dt-blob.dtbo \
 	revpi-connect.dtbo \
 	revpi-connect-dt-blob.dtbo \
+	revpi-connect-se.dtbo \
+	revpi-connect-se-dt-blob.dtbo \
 	revpi-con-can.dtbo \
 	revpi-flat.dtbo \
 	revpi-flat-dt-blob.dtbo \

--- a/arch/arm/boot/dts/overlays/revpi-connect-se-dt-blob-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-se-dt-blob-overlay.dts
@@ -1,0 +1,7 @@
+/*
+ * Device tree blob overlay for Revolution Pi by KUNBUS
+ *
+ * RevPi Connect SE
+ */
+
+#include "revpi-connect-dt-blob-overlay.dts"

--- a/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
@@ -1,0 +1,46 @@
+/*
+ * Device tree overlay for Revolution Pi by KUNBUS
+ *
+ * RevPi Connect SE
+ */
+
+#include "revpi-connect-overlay.dts"
+
+/{
+	compatible = "brcm,bcm2837";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			compatible = "kunbus,revpi-connect-se", "brcm,bcm2837",
+				     "brcm,bcm2836";
+			/delete-node/ regulator_pbrst;
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			spi0_cs_pins: spi0_cs_pins {
+				brcm,pins     = <36>;
+				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+				brcm,pull     = <BCM2835_PUD_OFF>;
+			};
+			/delete-node/ eth2_int_pins;
+			/delete-node/ eth2_reset_pins;
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			cs-gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+			/delete-node/ ethernet@1;
+		};
+	};
+
+	__overrides__ {
+		/delete-property/ pileft_mac_hi;
+		/delete-property/ pileft_mac_lo;
+	};
+};


### PR DESCRIPTION
The Connect SE comes without ethernet interface on pibridge by
comparing with Connect, so based on the device tree overlay of
Connect the following related configurations can be removed:

Configuration of the regulator_pbrst
Configuration of spi pins for ksz8851, and pileft