### PR TITLE
Some changes about dts/connect se [REVPI-2285]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
@@ -12,8 +12,7 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
-			compatible = "kunbus,revpi-connect-se", "brcm,bcm2837",
-				     "brcm,bcm2836";
+			compatible = "kunbus,revpi-connect-se", "brcm,bcm2711";
 			/delete-node/ regulator_pbrst;
 		};
 	};

--- a/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-se-overlay.dts
@@ -17,20 +17,16 @@
 		};
 	};
 
-	fragment@1 {
-		target = <&gpio>;
+	fragment@6 {
+		target = <&spi0_cs_pins>;
 		__overlay__ {
-			spi0_cs_pins: spi0_cs_pins {
-				brcm,pins     = <36>;
-				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
-				brcm,pull     = <BCM2835_PUD_OFF>;
-			};
-			/delete-node/ eth2_int_pins;
-			/delete-node/ eth2_reset_pins;
+			brcm,pins     = <36 35>;
+			brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+			brcm,pull     = <BCM2835_PUD_OFF>;
 		};
 	};
 
-	fragment@4 {
+	fragment@7 {
 		target = <&spi0>;
 		__overlay__ {
 			cs-gpios = <&gpio 36 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
1. change the compatible string
2. adjust the fragments to align with "dts/connect: Use own fragments to modify existing pinmuxes"