### PR TITLE
dts/core: Use own fragments to modify existing pinmuxes [REVPI-2293]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -83,27 +83,10 @@
 	fragment@1 {
 		target = <&gpio>;
 		__overlay__ {
-			spi0_pins: spi0_pins {
-				/* miso mosi clock */
-				brcm,pins     = <37 38 39>;
-				brcm,function = <BCM2835_FSEL_ALT0>;
-				brcm,pull     = <BCM2835_PUD_OFF>;
-			};
-			spi0_cs_pins: spi0_cs_pins {
-				brcm,pins     = <36 35>;
-				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
-				brcm,pull     = <BCM2835_PUD_OFF>;
-			};
 			eth1_2_reset_pins: eth1_2_reset_pins {
 				/* resets both chips */
 				brcm,pins     = <40>;
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
-				brcm,pull     = <BCM2835_PUD_OFF>;
-			};
-			i2c1_pins: i2c1_pins {
-				/* sda scl */
-				brcm,pins     = <44 45>;
-				brcm,function = <BCM2835_FSEL_ALT2>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			sniff_pins: sniff_pins {
@@ -138,6 +121,16 @@
 	};
 
 	fragment@2 {
+		target = <&i2c1_pins>;
+		__overlay__ {
+			/* sda scl */
+			brcm,pins     = <44 45>;
+			brcm,function = <BCM2835_FSEL_ALT2>;
+			brcm,pull     = <BCM2835_PUD_OFF>;
+		};
+	};
+
+	fragment@3 {
 		target = <&i2c1>;
 		__overlay__ {
 			pinctrl-names = "default";
@@ -160,21 +153,40 @@
 		};
 	};
 
-	fragment@3 {
+	fragment@4 {
 		target = <&spidev0>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@4 {
+	fragment@5 {
 		target = <&spidev1>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@5 {
+	fragment@6 {
+		target = <&spi0_pins>;
+		__overlay__ {
+			/* miso mosi clock */
+			brcm,pins     = <37 38 39>;
+			brcm,function = <BCM2835_FSEL_ALT0>;
+			brcm,pull     = <BCM2835_PUD_OFF>;
+		};
+	};
+
+	fragment@7 {
+		target = <&spi0_cs_pins>;
+		__overlay__ {
+			brcm,pins     = <36 35>;
+			brcm,function = <BCM2835_FSEL_GPIO_OUT>;
+			brcm,pull     = <BCM2835_PUD_OFF>;
+		};
+	};
+
+	frgment@8 {
 		target = <&spi0>;
 		__overlay__ {
 			pinctrl-names = "default";
@@ -207,7 +219,7 @@
 		};
 	};
 
-	fragment@6 {
+	fragment@9 {
 		target = <&usb>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -227,7 +239,7 @@
 		};
 	};
 
-	fragment@7 {
+	fragment@10 {
 		target = <&uart0>;
 		__overlay__ {
 			pinctrl-names = "default";


### PR DESCRIPTION
If we redefine muxes which are already defined in the devicetree we
might get errors when loading the overlay at runtime. There is no
usefull error message. It just says the loding of the overlay faild. The
bootloader seems not so picky and loads the overlay.

We move each pinmux which is already defined in bcm2708-rpi-cm.dts,
bcm2710-rpi-cm3.dts or bcm2711-rpi-cm4s.dts, to its own fragment. And we
modify the already defined pinmux instead of creating a new one.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>