### PR TITLE
dts/core: Fix typo in the spi0 fragment [REVPI-2298]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -186,7 +186,7 @@
 		};
 	};
 
-	frgment@8 {
+	fragment@8 {
 		target = <&spi0>;
 		__overlay__ {
 			pinctrl-names = "default";


### PR DESCRIPTION
Commit 5dba555f0606 ("dts/core: Use own fragments to modify existing
pinmuxes") introduced a typo: "frgment@8". It must say "fragment@8".
With this typo the fragment is not applied. Thus leads to the situation
that spi0 is not enabled. And picontrol won't even load because the spi0
thread is missing.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>