### PR TITLE
dts/compact: Switch to dwc2 USB driver [REVPI-2336]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
@@ -304,10 +304,15 @@
 
 	fragment@7 {
 		target = <&usb>;
-		__overlay__ {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dwc2_usb: __overlay__ {
+			compatible = "brcm,bcm2835-usb";
 			dr_mode = "host";
-			#address-cells = <1>;
-			#size-cells = <0>;
+			g-np-tx-fifo-size = <32>;
+			g-rx-fifo-size = <558>;
+			g-tx-fifo-size = <512 512 512 512 512 256 256>;
+			status = "okay";
 
 			hub@1 {
 				compatible = "usb424,9514"; /* SMSC LAN9514 */


### PR DESCRIPTION
This enables the dwc2 on the compact. I mostly copied the stuff from the dwc2 overlay to our overlay.

I've ran a 30 min test with iperf3 and ping without any problems. I didn't do any other test.
```
--- 10.25.26.164 ping statistics ---
1800 packets transmitted, 1800 received, 0% packet loss, time 1801562ms
rtt min/avg/max/mdev = 0.383/20.719/25.156/1.786 ms
```
```
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-1800.00 sec  19.7 GBytes  94.2 Mbits/sec    0             sender
[  5]   0.00-1800.00 sec  19.7 GBytes  94.2 Mbits/sec                  receiver
```
```
top - 16:55:37 up  1:02,  2 users,  load average: 3.39, 2.82, 3.01
Tasks: 140 total,   2 running, 138 sleeping,   0 stopped,   0 zombie
%Cpu(s):  0.6 us, 39.9 sy,  0.0 ni, 50.7 id,  0.0 wa,  0.0 hi,  8.8 si,  0.0 st
MiB Mem :    923.2 total,    740.5 free,     61.2 used,    121.5 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.    802.4 avail Mem 

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                          
   87 root     -51   0       0      0      0 S  67.4   0.0  23:42.66 irq/66-dwc2_hso                                  
 2643 pi        20   0    5652   3420   3092 R  28.0   0.4   0:02.67 iperf3                                           
   84 root     -51   0       0      0      0 S  26.0   0.0  11:48.96 irq/66-3f980000                                  
  171 root     -59   0       0      0      0 D  20.7   0.0  12:40.45 piControl i/o                                    
  161 root     -61   0       0      0      0 S  11.8   0.0   7:05.79 spi2                                             
 2644 pi        20   0   10432   2960   2520 R   1.0   0.3   0:00.09 top                                              
   12 root      20   0       0      0      0 S   0.3   0.0   0:04.97 ksoftirqd/0                                      
   37 root      20   0       0      0      0 S   0.3   0.0   0:03.88 ksoftirqd/3                                      
  154 root      20   0       0      0      0 S   0.3   0.0   0:00.77 spi0                                             
 2011 root      20   0       0      0      0 I   0.3   0.0   0:00.42 ks8851_tx                                        
    1 root      20   0   33604   7844   6276 S   0.0   0.8   0:04.98 systemd 
```

(Recreate the PR from the revpi repo)