### PR TITLE
dts/revpi-*: Switch to dwc2 USB driver [REVPI-2351]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-compact-overlay.dts
@@ -304,10 +304,15 @@
 
 	fragment@7 {
 		target = <&usb>;
-		__overlay__ {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dwc2_usb: __overlay__ {
+			compatible = "brcm,bcm2835-usb";
 			dr_mode = "host";
-			#address-cells = <1>;
-			#size-cells = <0>;
+			g-np-tx-fifo-size = <32>;
+			g-rx-fifo-size = <558>;
+			g-tx-fifo-size = <512 512 512 512 512 256 256>;
+			status = "okay";
 
 			hub@1 {
 				compatible = "usb424,9514"; /* SMSC LAN9514 */

--- a/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect-overlay.dts
@@ -227,9 +227,15 @@
 
 	fragment@8 {
 		target = <&usb>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dwc2_usb: __overlay__ {
+			compatible = "brcm,bcm2835-usb";
+			dr_mode = "host";
+			g-np-tx-fifo-size = <32>;
+			g-rx-fifo-size = <558>;
+			g-tx-fifo-size = <512 512 512 512 512 256 256>;
+			status = "okay";
 
 			hub@1 {
 				/* SMSC LAN9514 */

--- a/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-overlay.dts
@@ -221,9 +221,15 @@
 
 	fragment@9 {
 		target = <&usb>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dwc2_usb: __overlay__ {
+			compatible = "brcm,bcm2835-usb";
+			dr_mode = "host";
+			g-np-tx-fifo-size = <32>;
+			g-rx-fifo-size = <558>;
+			g-tx-fifo-size = <512 512 512 512 512 256 256>;
+			status = "okay";
 
 			hub@1 {
 				compatible = "usb424,9514"; /* SMSC LAN9514 */

--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -284,9 +284,15 @@
 
 	fragment@7 {
 		target = <&usb>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dwc2_usb: __overlay__ {
+			compatible = "brcm,bcm2835-usb";
+			dr_mode = "host";
+			g-np-tx-fifo-size = <32>;
+			g-rx-fifo-size = <558>;
+			g-tx-fifo-size = <512 512 512 512 512 256 256>;
+			status = "okay";
 
 			hub@1 {
 				/* SMSC LAN9514 */


### PR DESCRIPTION
With the 5.10 kernel we see issues with the USB based network interface.
Some times the USB interface seems to be stalled and communication is
susspended. The received packages are processed after some time. The
delay can go up to several 10th seconds.
The issue seems to be with the usb_otg driver in combination with
piControl. Balancing the priorities (increase the dwc-otg irq threads
priorities or decreasing the piControl threads priorities) reduces the
problems, but doesn't solve them. The dwc2 driver has been developed
further while the development of the dwc-otg driver stagnated. So it
seems that the dwc2 driver doesn't suffer from these issues. So
switching to the dwc2 driver seems the obvious solution.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>