### PR TITLE
dts: Add RevPi Core S (2022) overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -176,6 +176,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	revpi-core.dtbo \
 	revpi-core-dt-blob.dtbo \
 	revpi-core-2022.dtbo \
+	revpi-core-s-2022.dtbo \
 	cmio-jtag-dt-blob.dtbo \
 	rotary-encoder.dtbo \
 	rpi-backlight.dtbo \

--- a/arch/arm/boot/dts/overlays/revpi-core-2022-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-2022-overlay.dts
@@ -14,7 +14,8 @@
 	fragment@0 {
 		target-path = "/";
 		__overlay__ {
-			compatible = "kunbus,revpi-core-2022", "brcm,bcm2837";
+			compatible = "kunbus,revpi-core-2022",
+				     "kunbus,revpi-core", "brcm,bcm2837";
 			/delete-node/ regulator_pbrst;
 		};
 	};

--- a/arch/arm/boot/dts/overlays/revpi-core-s-2022-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-s-2022-overlay.dts
@@ -1,0 +1,19 @@
+/*
+ * Device tree overlay for Revolution Pi by KUNBUS
+ *
+ * RevPi Core S (2022)
+ */
+
+ #include "revpi-core-2022-overlay.dts"
+
+/{
+	compatible = "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			compatible = "kunbus,revpi-core-s-2022",
+				     "kunbus,revpi-core", "brcm,bcm2711";
+		};
+	};
+};


### PR DESCRIPTION
The RevPi Core S (2022) is the same as the RevPi Core 3 (2022) but uses
a CM4S module and thus a BCM2711 SoC.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>