### PR TITLE
dts/revpi-flat: Add WLAN enable [revpi2356]

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -36,6 +36,11 @@
 				regulator-always-on;
 			};
 
+			wl_on: reg_wl {
+				compatible = "mmc-pwrseq-simple";
+				reset-gpios = <&expander 10 GPIO_ACTIVE_LOW>;
+			};
+
 			watchdog: watchdog {
 				pinctrl-names = "default";
 				pinctrl-0 = <&watchdog_gpio4>;
@@ -337,6 +342,7 @@
 			bus-width = <4>;
 			non-removable;
 			max-frequency = <28000000>;
+			mmc-pwrseq = <&wl_on>;
 
 			wlan0: wifi@1 {
 				reg = <1>;


### PR DESCRIPTION
Newer RevPi Flat have a dedicated enable signal to take the CYW43455
wlan module out of reset. The signal is accessible through the GPIO
expander (gpio10/P1_2) on the top board.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>