### PR TITLE
dts/core-se: Add the initial device tree overlay [REVPI-1965]

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -177,6 +177,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	revpi-core-dt-blob.dtbo \
 	revpi-core-2022.dtbo \
 	revpi-core-s-2022.dtbo \
+	revpi-core-se-2022.dtbo \
 	cmio-jtag-dt-blob.dtbo \
 	rotary-encoder.dtbo \
 	rpi-backlight.dtbo \

--- a/arch/arm/boot/dts/overlays/revpi-core-se-2022-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-se-2022-overlay.dts
@@ -1,0 +1,40 @@
+/*
+ * Device tree overlay for Revolution Pi by KUNBUS
+ *
+ * RevPi Core SE (2022)
+ */
+
+ #include "revpi-core-s-2022-overlay.dts"
+
+/{
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			compatible = "kunbus,revpi-core-se-2022",
+				     "kunbus,revpi-core-se", "brcm,bcm2711";
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			/delete-node/ pileft_pins;
+			/delete-node/ piright_pins;
+		};
+	};
+
+	fragment@8 {
+		target = <&spi0>;
+		__overlay__ {
+			/delete-node/ ethernet@0;
+			/delete-node/ ethernet@1;
+		};
+	};
+
+	__overrides__ {
+		/delete-property/ pileft_mac_hi;
+		/delete-property/ pileft_mac_lo;
+		/delete-property/ piright_mac_hi;
+		/delete-property/ piright_mac_lo;
+	};
+};


### PR DESCRIPTION
The Core SE is based on Core S (revpi-core-s-2022-overlay.dts), but
without eth chip in the pribridge, so the device tree overlay comes
with following changes:

 * Configuration of pileft, piright are removed
 * The overrided properties for mac address are removed

Signed-off-by: Zhi Han <z.han@kunbus.com>
Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>