### PR TITLE
ARM: dts: Enable USB by default on CM4S

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4s.dts
@@ -405,6 +405,16 @@
 // =============================================
 // Board specific stuff here
 
+/* Enable USB in OTG-aware mode */
+&usb {
+	compatible = "brcm,bcm2835-usb";
+	dr_mode = "otg";
+	g-np-tx-fifo-size = <32>;
+	g-rx-fifo-size = <558>;
+	g-tx-fifo-size = <512 512 512 512 512 256 256>;
+	status = "okay";
+};
+
 &sdhost {
 	status = "disabled";
 };


### PR DESCRIPTION
[from upstream commit 218160e6b050]

Signed-off-by: Phil Elwell <phil@raspberrypi.com>
Signed-off-by: Frank Erdrich <f.erdrich@kunbus.com>