### PR TITLE
arm: dts: flat: correct relais pin

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-flat-overlay.dts
@@ -151,7 +151,7 @@
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			relais_pins: relais_pins {
-				brcm,pins     = <19>;
+				brcm,pins     = <28>;
 				brcm,function = <BCM2835_FSEL_GPIO_OUT>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};


### PR DESCRIPTION
Correct relais pin from GPIO 19 to GPIO 28.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>