### PR TITLE
arm/dts: Add overlay for RevPi HAT EEPROMs [REVPI-2711]

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -175,6 +175,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	revpi-flat.dtbo \
 	revpi-flat-s-2022.dtbo \
 	revpi-flat-dt-blob.dtbo \
+	revpi-hat-eeprom.dtbo \
 	revpi-core.dtbo \
 	revpi-core-cm1.dtbo \
 	revpi-core-dt-blob.dtbo \

--- a/arch/arm/boot/dts/overlays/revpi-hat-eeprom-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-hat-eeprom-overlay.dts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright 2022 KUNBUS GmbH
+ */
+
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c0if>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c0_pins>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <400000>;
+			status = "okay";
+
+			eeprom: eeprom@50 {
+				compatible = "atmel,24c256";
+				reg = <0x50>;
+				pagesize = <64>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/aliases";
+		__overlay__ {
+			i2c0 = "/soc/i2c@7e205000";
+		};
+	};
+
+	fragment@2 {
+		target-path = "/__symbols__";
+		__overlay__ {
+			i2c0 = "/soc/i2c@7e205000";
+		};
+	};
+};


### PR DESCRIPTION
This overlay can be used to make the RevPi HAT EEPROM available. The overlay should only be used to flash the HAT EEPROM. Loading this overlay by default might have undesired side effects. The HAT EEPROM is attached to the i2c0 which is shared with the video core. On some RevPi devices it might trigger a reset of the periphery if the reset is not actively disabled. How the reset is disable is board specific.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>