### PR TITLE
CI: Build snapshot packages for arm and arm64 [REVPI-2715]

### DIFF
--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -12,29 +12,29 @@ jobs:
       kernelbakery_branch: master
       picontrol_branch: master
       build_commit: ${{ github.event.pull_request.head.sha }}
-  link_artifacts:
-    name: link artifacts in PR
-    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') }}
-    needs: kernelbakery_snapshot
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v5
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '📦 Your snapshot packages are ready! https://github.com/RevolutionPi/linux/actions/runs/${{github.run_id}}'
-            })
-      - uses: actions/github-script@v5
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'snapshot-packages'
-            })
+  # link_artifacts:
+  #   name: link artifacts in PR
+  #   if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') }}
+  #   needs: kernelbakery_snapshot
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/github-script@v5
+  #       with:
+  #         github-token: ${{secrets.GITHUB_TOKEN}}
+  #         script: |
+  #           github.rest.issues.createComment({
+  #             issue_number: context.issue.number,
+  #             owner: context.repo.owner,
+  #             repo: context.repo.repo,
+  #             body: '📦 Your snapshot packages are ready! https://github.com/RevolutionPi/linux/actions/runs/${{github.run_id}}'
+  #           })
+  #     - uses: actions/github-script@v5
+  #       with:
+  #         github-token: ${{secrets.GITHUB_TOKEN}}
+  #         script: |
+  #           github.rest.issues.removeLabel({
+  #             issue_number: context.issue.number,
+  #             owner: context.repo.owner,
+  #             repo: context.repo.repo,
+  #             name: 'snapshot-packages'
+  #           })

--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -4,14 +4,28 @@ on:
     types:
       - labeled
 jobs:
-  kernelbakery_snapshot:
-    name: snapshot
-    if: ${{ github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages'}}
+  kernelbakery_snapshot_arm:
+    name: Snapshot Packages ARM
+    if: |
+      github.event_name == 'pull_request' && 
+      (github.event.label.name == 'snapshot-packages' || github.event.label.name == 'snapshot-packages-arm')
     uses:  RevolutionPi/ci-workflows/.github/workflows/kernel-snapshot.yml@main
     with:
       kernelbakery_branch: master
       picontrol_branch: master
       build_commit: ${{ github.event.pull_request.head.sha }}
+      arch: arm
+  kernelbakery_snapshot_arm64:
+    name: Snapshot Packages ARM64
+    if: |
+      github.event_name == 'pull_request' && 
+      (github.event.label.name == 'snapshot-packages' || github.event.label.name == 'snapshot-packages-arm64')
+    uses:  RevolutionPi/ci-workflows/.github/workflows/kernel-snapshot.yml@main
+    with:
+      kernelbakery_branch: master
+      picontrol_branch: master
+      build_commit: ${{ github.event.pull_request.head.sha }}
+      arch: arm64
   # link_artifacts:
   #   name: link artifacts in PR
   #   if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'snapshot-packages') }}


### PR DESCRIPTION
From now on there will be also arm64 snapshot packages, if the label `snapshot-packages` is specified in a PR . In order to build only `arm` or `arm64` snapshot packages, the labels `snapshot-packages-arm` or `snapshot-packages-arm64` can be used.