### PR TITLE
Revpi 2545/investigate high cyclus latency

### DIFF
--- a/drivers/tty/serdev/pibridge.c
+++ b/drivers/tty/serdev/pibridge.c
@@ -60,7 +60,7 @@ static int pibridge_receive_buf(struct serdev_device *serdev,
 	ret = kfifo_in(&pi->read_fifo, buf, count);
 	mutex_unlock(&pi->lock);
 
-	wake_up_interruptible(&pi->read_queue);
+	wake_up(&pi->read_queue);
 
 	if (ret < count)
 		dev_warn_ratelimited(&serdev->dev,


### PR DESCRIPTION
This is base on [linosanfilippo-kunbus:revpi-2545/use_serdev_highlevel_functions](https://github.com/linosanfilippo-kunbus/linux/tree/revpi-2545/use_serdev_highlevel_functions). For review only take the last 2 commits into account until the other PR is merged.