### PR TITLE
WIP: Fix dwc_otg for RevPi Connect 3 [REVPI-2798]

### DIFF
--- a/drivers/usb/host/dwc_otg/Makefile
+++ b/drivers/usb/host/dwc_otg/Makefile
@@ -28,6 +28,7 @@ ccflags-y   	+= -DDWC_LINUX
 ccflags-y   	+= $(CFI)
 ccflags-y	+= $(BUS_INTERFACE)
 #ccflags-y	+= -DDWC_DEV_SRPCAP
+CFLAGS_dwc_otg_fiq_fsm.o += -fno-stack-protector
 
 obj-$(CONFIG_USB_DWCOTG) += dwc_otg.o
 

--- a/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_fiq_fsm.c
@@ -142,7 +142,7 @@ inline void fiq_fsm_spin_unlock(fiq_lock_t *lock) { }
  * fiq_fsm_restart_channel() - Poke channel enable bit for a split transaction
  * @channel: channel to re-enable
  */
-static void fiq_fsm_restart_channel(struct fiq_state *st, int n, int force)
+static void notrace fiq_fsm_restart_channel(struct fiq_state *st, int n, int force)
 {
 	hcchar_data_t hcchar = { .d32 = FIQ_READ(st->dwc_regs_base + HC_START + (HC_OFFSET * n) + HCCHAR) };
 

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.c
@@ -301,6 +301,7 @@ static int32_t dwc_otg_hcd_disconnect_cb(void *p)
 {
 	gintsts_data_t intr;
 	dwc_otg_hcd_t *dwc_otg_hcd = p;
+	unsigned long flags;
 
 	DWC_SPINLOCK(dwc_otg_hcd->lock);
 	/*
@@ -309,8 +310,7 @@ static int32_t dwc_otg_hcd_disconnect_cb(void *p)
 	dwc_otg_hcd->flags.b.port_connect_status_change = 1;
 	dwc_otg_hcd->flags.b.port_connect_status = 0;
 	if(fiq_enable) {
-		local_fiq_disable();
-		fiq_fsm_spin_lock(&dwc_otg_hcd->fiq_state->lock);
+		fiq_fsm_spin_lock_irqsave(&dwc_otg_hcd->fiq_state->lock, flags);
 	}
 	/*
 	 * Shutdown any transfers in process by clearing the Tx FIFO Empty
@@ -389,8 +389,7 @@ static int32_t dwc_otg_hcd_disconnect_cb(void *p)
 	}
 
 	if(fiq_enable) {
-		fiq_fsm_spin_unlock(&dwc_otg_hcd->fiq_state->lock);
-		local_fiq_enable();
+		fiq_fsm_spin_unlock_irqrestore(&dwc_otg_hcd->fiq_state->lock, flags);
 	}
 
 	if (dwc_otg_hcd->fops->disconnect) {
@@ -612,17 +611,16 @@ int dwc_otg_hcd_urb_dequeue(dwc_otg_hcd_t * hcd,
 			if (fiq_fsm_enable && (hcd->fiq_state->channel[n].fsm != FIQ_PASSTHROUGH)) {
 				int retries = 3;
 				int running = 0;
+				unsigned long flags;
 				enum fiq_fsm_state state;
 
-				local_fiq_disable();
-				fiq_fsm_spin_lock(&hcd->fiq_state->lock);
+				fiq_fsm_spin_lock_irqsave(&hcd->fiq_state->lock, flags);
 				qh->channel->halt_status = DWC_OTG_HC_XFER_URB_DEQUEUE;
 				qh->channel->halt_pending = 1;
 				if (hcd->fiq_state->channel[n].fsm == FIQ_HS_ISOC_TURBO ||
 				    hcd->fiq_state->channel[n].fsm == FIQ_HS_ISOC_SLEEPING)
 					hcd->fiq_state->channel[n].fsm = FIQ_HS_ISOC_ABORTED;
-				fiq_fsm_spin_unlock(&hcd->fiq_state->lock);
-				local_fiq_enable();
+				fiq_fsm_spin_unlock_irqrestore(&hcd->fiq_state->lock, flags);
 
 				if (dwc_qh_is_non_per(qh)) {
 					do {

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd_linux.c
@@ -807,7 +807,6 @@ static int dwc_otg_urb_enqueue(struct usb_hcd *hcd,
 	struct usb_host_endpoint *ep = urb->ep;
 #endif
 	dwc_irqflags_t irqflags;
-        void **ref_ep_hcpriv = &ep->hcpriv;
 	dwc_otg_hcd_t *dwc_otg_hcd = hcd_to_dwc_otg_hcd(hcd);
 	dwc_otg_hcd_urb_t *dwc_otg_urb;
 	int i;
@@ -824,7 +823,7 @@ static int dwc_otg_urb_enqueue(struct usb_hcd *hcd,
 	if ((usb_pipetype(urb->pipe) == PIPE_ISOCHRONOUS)
 	    || (usb_pipetype(urb->pipe) == PIPE_INTERRUPT)) {
 		if (!dwc_otg_hcd_is_bandwidth_allocated
-		    (dwc_otg_hcd, ref_ep_hcpriv)) {
+		    (dwc_otg_hcd, ep->hcpriv)) {
 			alloc_bandwidth = 1;
 		}
 	}
@@ -911,13 +910,12 @@ static int dwc_otg_urb_enqueue(struct usb_hcd *hcd,
 #endif
 	{
 		retval = dwc_otg_hcd_urb_enqueue(dwc_otg_hcd, dwc_otg_urb,
-						/*(dwc_otg_qh_t **)*/
-						ref_ep_hcpriv, 1);
+						&ep->hcpriv, 1);
 		if (0 == retval) {
 			if (alloc_bandwidth) {
 				allocate_bus_bandwidth(hcd,
 						dwc_otg_hcd_get_ep_bandwidth(
-							dwc_otg_hcd, *ref_ep_hcpriv),
+							dwc_otg_hcd, ep->hcpriv),
 						urb);
 			}
 		} else {


### PR DESCRIPTION
```
[    3.241754] ------------[ cut here ]------------                                                                                                                                                                                                           
[    3.241760] WARNING: CPU: 0 PID: 90 at kernel/rcu/tree_plugin.h:297 rcu_note_context_switch+0x64/0x438                                                                                                                                                     
[    3.241783] Modules linked in:                                                           
[    3.241790] CPU: 0 PID: 90 Comm: irq/74-dwc_otg Not tainted 5.10.152-rt75-v8+ #1         
[    3.241798] Hardware name: Raspberry Pi Compute Module 3 Plus Rev 1.0 (DT)               
[    3.241802] pstate: 20000085 (nzCv daIf -PAN -UAO -TCO BTYPE=--)                         
[    3.241809] pc : rcu_note_context_switch+0x64/0x438                                      
[    3.241817] lr : rcu_note_context_switch+0x54/0x438     
[    3.241825] sp : ffffffc012bb3b90                                                        
[    3.241828] x29: ffffffc012bb3b90 x28: ffffff8002c8ec00                                  
[    3.241836] x27: 0000000000000000 x26: ffffffc01141a000                                  
[    3.241843] x25: 0000000000000000 x24: 0000000000000000                                  
[    3.241850] x23: 0000000000000000 x22: ffffff80021a0000                                  
[    3.241857] x21: ffffffc011406768 x20: ffffff80021a0000 
[    3.241865] x19: ffffff803719fa00 x18: 0000000000000010                                  
[    3.241872] x17: 00000000819d11e6 x16: 0000000025017cf7                                  
[    3.241879] x15: ffffffffffffffff x14: ffffffc010df45d8                                                                                                                              
[    3.241886] x13: ffffffc092d93d07 x12: ffffffc012d93d14                                  
[    3.241894] x11: 0000000000000040 x10: ffffffc0112c6108                                  
[    3.241901] x9 : ffffffc010abee28 x8 : ffffff8001c00270                                  
[    3.241908] x7 : 0000000000000000 x6 : ffffffc012bb3b80                                  
[    3.241914] x5 : 0000000000000001 x4 : ffffffc026209000                                  
[    3.241921] x3 : 0000000000000001 x2 : ffffffc010f85008                                  
[    3.241928] x1 : ffffffc026209000 x0 : 0000000000000003                                  
[    3.241935] Call trace:                                                                  
[    3.241938]  rcu_note_context_switch+0x64/0x438                                          
[    3.241946]  __schedule+0xc8/0x7f0                                                       
[    3.241954]  schedule+0x64/0x128                                                                                                                                                     
[    3.241959]  synchronize_irq+0x84/0xb8                                                   
[    3.241965]  disable_irq+0x3c/0x50                                                       
[    3.241970]  local_fiq_disable+0x28/0x38                                                 
[    3.241980]  dwc_otg_handle_common_intr+0x49c/0xe68                                      
[    3.241987]  dwc_otg_common_irq+0x1c/0x30                                                
[    3.241993]  irq_forced_thread_fn+0x44/0xc8                                              
[    3.242002]  irq_thread+0x174/0x238                                                      
[    3.242009]  kthread+0x194/0x198                                                         
[    3.242016]  ret_from_fork+0x10/0x30                                                     
[    3.242025] ---[ end trace 0000000000000002 ]---  
```