### PR TITLE
Relax data type of pibridge send and receive buffers

### DIFF
--- a/include/linux/pibridge_comm.h
+++ b/include/linux/pibridge_comm.h
@@ -2,16 +2,16 @@
 #ifndef _PIBRIDGE_COMM_H
 #define _PIBRIDGE_COMM_H
 
-int pibridge_req_io(u8 addr, u8 cmd, u8 *snd_buf, u8 snd_len, u8 *rcv_buf,
+int pibridge_req_io(u8 addr, u8 cmd, void *snd_buf, u8 snd_len, void *rcv_buf,
 		    u8 rcv_len);
-int pibridge_req_send_io(u8 addr, u8 cmd, u8 *snd_buf, u8 snd_len);
-int pibridge_req_gate(u8 dst, u16 cmd, u8 *snd_buf, u8 snd_len,
-		      u8 *rcv_buf, u8 rcv_len);
-int pibridge_req_gate_tmt(u8 dst, u16 cmd, u8 *snd_buf, u8 snd_len,
-			  u8 *rcv_buf, u8 rcv_len, u16 tmt);
-int pibridge_req_send_gate(u8 dst, u16 cmd, u8 *snd_buf, u8 snd_len);
-int pibridge_recv(u8 *buf, u8 len);
-int pibridge_recv_timeout(u8 *buf, u8 len, u16 timeout);
-int pibridge_send(u8 *buf, u8 len);
+int pibridge_req_send_io(u8 addr, u8 cmd, void *snd_buf, u8 snd_len);
+int pibridge_req_gate(u8 dst, u16 cmd, void *snd_buf, u8 snd_len,
+		      void *rcv_buf, u8 rcv_len);
+int pibridge_req_gate_tmt(u8 dst, u16 cmd, void *snd_buf, u8 snd_len,
+			  void *rcv_buf, u8 rcv_len, u16 tmt);
+int pibridge_req_send_gate(u8 dst, u16 cmd, void *snd_buf, u8 snd_len);
+int pibridge_recv(void *buf, u8 len);
+int pibridge_recv_timeout(void *buf, u8 len, u16 timeout);
+int pibridge_send(void *buf, u8 len);
 void pibridge_clear_fifo(void);
 #endif	/* _PIBRIDGE_COMM_H */


### PR DESCRIPTION
Forcing callers to pass u8 * pointers to the pibridge API is cumbersome as it results in plenty of type casts. Avoid by switching to void * pointers.