### PR TITLE
pibridge-serdev: fix bad cycle times

### DIFF
--- a/drivers/tty/serdev/pibridge.c
+++ b/drivers/tty/serdev/pibridge.c
@@ -83,9 +83,9 @@ static int pibridge_discard_timeout(u16 len, u16 timeout)
 	unsigned int discarded;
 	int ret = 0;
 
-	wait_event_timeout(pi->read_queue,
-			   kfifo_len(&pi->read_fifo) >= len,
-			   msecs_to_jiffies(timeout) + 1);
+	wait_event_hrtimeout(pi->read_queue,
+			     kfifo_len(&pi->read_fifo) >= len,
+			     ms_to_ktime(timeout));
 
 	mutex_lock(&pi->lock);
 	discarded = kfifo_len(&pi->read_fifo);
@@ -184,8 +184,8 @@ int pibridge_recv_timeout(void *buf, u8 len, u16 timeout)
 
 	trace_pibridge_receive_begin(len);
 
-	wait_event_timeout(pi->read_queue, kfifo_len(&pi->read_fifo) >= len,
-			   msecs_to_jiffies(timeout) + 1);
+	wait_event_hrtimeout(pi->read_queue, kfifo_len(&pi->read_fifo) >= len,
+			     ms_to_ktime(timeout));
 
 	mutex_lock(&pi->lock);
 	received = kfifo_out(&pi->read_fifo, buf, len);


### PR DESCRIPTION
Use wait_event_hrtimeout() instead of wait_event_timeout() to wait for more data. The latter uses jiffies to specify the timeout which requires a minimum of 2 jiffies (which equals 20 msecs) to avoid a timeout before the the IO timeout interval used by the pibridge module (10 msecs) have passed.

With wait_event_hrtimeout() it is possible to specify the exact 10 msecs as a timeout so we do not have to wait up to 20 msecs in case that no more data arrives.