### PR TITLE
Task/revpi 3082/connect4 dt pciswitchless

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -273,6 +273,7 @@
 			pinctrl-0 = <&rs485_pins>;
 			status = "okay";
 			linux,rs485-enabled-at-boot-time;
+			rs485-rts-active-low;
 			rs485-term-gpios = <&expander_power 4 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -22,10 +22,10 @@
 				connect-gpios = <&gpio 6 GPIO_ACTIVE_HIGH>,
 						<&gpio 16 GPIO_ACTIVE_HIGH>;
 
-				left-sniff-gpios = <&expander_core 8 GPIO_ACTIVE_HIGH>,
-						   <&expander_core 9 GPIO_ACTIVE_HIGH>;
-				right-sniff-gpios = <&expander_core 11 GPIO_ACTIVE_HIGH>,
-						   <&expander_core 12 GPIO_ACTIVE_HIGH>;
+				left-sniff-gpios = <&expander_core 9 GPIO_ACTIVE_HIGH>,
+						   <&expander_core 8 GPIO_ACTIVE_HIGH>;
+				right-sniff-gpios = <&expander_core 12 GPIO_ACTIVE_HIGH>,
+						   <&expander_core 11 GPIO_ACTIVE_HIGH>;
 			};
 
 			leds {

--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -147,9 +147,7 @@
 			rs485_pins: rs485_pins {
 				/* TX RX TX_EN */
 				brcm,pins     = <12 13 15>;
-				brcm,function = <BCM2835_FSEL_ALT4
-				                 BCM2835_FSEL_ALT4
-				                 BCM2835_FSEL_ALT4>;
+				brcm,function = <BCM2835_FSEL_ALT4>;
 				brcm,pull     = <BCM2835_PUD_OFF>;
 			};
 			spi1_cs_pins: spi1_cs_pins {


### PR DESCRIPTION
Applied two WIP patches, one for the sniff pins and one for the rs485.
Added a small unifying to one of the pinctrls.

Checked all peripherals and pull-up/-down settings against the schematic.

Unsure about the ETH_SYNC. It seems to be a feature of pibridge2.0, which isn't implemented in this version of the product, so it shouldn't have any effect if the pin isn't configured correctly or has a wrong default state. There's a buffer with a dedicated output enable, so if that output enable is controlled in the correct way (or simplay relying on the pullup), ETH_SYNC should never have an impact on the output side of the buffer and therefore on the pibridge. But maybe I'm wrong. Could someone have an additional look at this specific pin?