### PR TITLE
net: phy: broadcom: Make LEDs 3+4 shadow LEDs 1+2 [REVPI-3119]

### DIFF
--- a/drivers/net/phy/broadcom.c
+++ b/drivers/net/phy/broadcom.c
@@ -386,6 +386,11 @@ static int bcm54xx_config_init(struct phy_device *phydev)
 	val = BCM5482_SHD_LEDS1_LED1(BCM_LED_SRC_MULTICOLOR1) |
 		BCM5482_SHD_LEDS1_LED3(BCM_LED_SRC_MULTICOLOR1);
 	bcm_phy_write_shadow(phydev, BCM5482_SHD_LEDS1, val);
+	/* BCM54210PE controls two extra LEDs with the next register.
+	 * Make them shadow the first pair of LEDs - useful on CM4 which
+	 * uses LED3 for ETH_LEDY instead of LED1.
+	 */
+	bcm_phy_write_shadow(phydev, BCM5482_SHD_LEDS1 + 1, val);
 
 	val = BCM_LED_MULTICOLOR_IN_PHASE |
 		BCM5482_SHD_LEDS1_LED1(led_modes[0]) |


### PR DESCRIPTION
commit 326dea65f88e75d25960ecce49df23a0d76bbac0 upstream (rpi)

CM4 uses BCM54210PE, which supports 2 additional LEDs, choosing LED3 for the amber LED because it shows activity by default (LED4 is not connected). However, this makes it uncontrollable by the eth_led<n> dtparams which target LEDs 1+2.

Solve the problem by making LEDs 3+4 mirror LEDs 1+2 (which is much simpler than adding baseboard-specific overrides, but comes with a risk of making one of the LEDs redundant).

See: https://github.com/raspberrypi/linux/issues/5289