### PR TITLE
revpi 5.10: Some serdev findings

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -285,6 +285,10 @@
 			pinctrl-0 = <&pb_uart_pins>;
 			status = "okay";
 			linux,rs485-enabled-at-boot-time;
+
+			pi_bridge {
+				compatible = "kunbus,pi-bridge";
+			};
 		};
 	};
 

--- a/drivers/tty/serdev/pibridge.c
+++ b/drivers/tty/serdev/pibridge.c
@@ -324,7 +324,7 @@ int pibridge_req_gate_tmt(u8 dst, u16 cmd, void *snd_buf, u8 snd_len,
 
 	if (crc != crc_rcv) {
 		dev_warn_ratelimited(&pibridge_s->serdev->dev,
-			"invalid checksum (expected: 0x%02x, got 0x%02x\n",
+			"invalid checksum (expected: 0x%02x, got 0x%02x)\n",
 			crc_rcv, crc);
 			return -EBADMSG;
 	}


### PR DESCRIPTION
- Enable serdev in RevPi Connect 4
- Fix missing bracket in serdev debug output

(same as in #150)