### PR TITLE
Connect4: Swap LED mode of SoC Ethernet

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -294,4 +294,13 @@
 			/* No configuration till now*/
 		};
 	};
+
+	/* PHY1 (SoC Ethernet) */
+	fragment@8 {
+		target = <&phy1>;
+		__overlay__ {
+			/* Link Speed/Activity */
+			led-modes = <0x08 0x00>;
+		};
+	};
 };


### PR DESCRIPTION
Existing RevPi products use a green LED to signify link presence and an amber LED to signify activity.

The Connect 4's LAN7800 Ethernet retains that color scheme, but the SoC Ethernet does not:  It uses green for activity and amber for link.

Invert the color scheme of the SoC Ethernet for consistency.

An effort is ongoing in mainline to introduce a standardized API and DeviceTree schema for Ethernet LED modes.  It's still in review though, so use the Foundation's custom DeviceTree property for now:

https://lore.kernel.org/all/20230427001541.18704-1-ansuelsmth@gmail.com/