### PR TITLE
dts: connect4: Correct fragment numbering

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -321,7 +321,7 @@
 	};
 
 	/* PHY1 (SoC Ethernet) */
-	fragment@8 {
+	fragment@9 {
 		target = <&phy1>;
 		__overlay__ {
 			/* Link Speed/Activity */


### PR DESCRIPTION
Fragment number 8 exits twice in the overlay, leading to a compiler error. Fix that.

Fixes: 8ed5d87aba32 ("dts: connect4: Add debug UART 1 (TX only)")