### PR TITLE
ARM: dts: bcm2711: Choose antenna for CM4 in device tree overlays

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
@@ -99,13 +99,11 @@
 		ant1: ant1 {
 			gpio-hog;
 			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-high;
 		};
 
 		ant2: ant2 {
 			gpio-hog;
 			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-low;
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -328,4 +328,18 @@
 			led-modes = <0x08 0x00>;
 		};
 	};
+
+	fragment@10 {
+		target = <&ant1>;
+		__overlay__ {
+                        output-low;
+		};
+	};
+
+	fragment@11 {
+		target = <&ant2>;
+		__overlay__ {
+                        output-high;
+		};
+	};
 };


### PR DESCRIPTION
For CM4 do not set the antenna in the device tree but provide overlays to configure the external/internal antenna.
This eliminates the requirement to set the antenna in the config.txt by means of a device tree parameter.