### PR TITLE
dts: core-se: Disable spi0

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-core-se-2022-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-core-se-2022-overlay.dts
@@ -25,6 +25,8 @@
 
 	fragment@8 {
 		target = <&spi0>;
+		status = "disabled";
+
 		__overlay__ {
 			/delete-node/ ethernet@0;
 			/delete-node/ ethernet@1;


### PR DESCRIPTION
The RevPi Core SE has no ethernet phys on the piBridge. As no other devices are connected to the spi0 bus, disable it.

This was brought to attention by @l1k during the Connect 4 piControl review: https://github.com/RevolutionPi/piControl/pull/94/commits/8780dc863822661b09b83431cb3c7813e6141471