### PR TITLE
dts: connect4: Switch left sniff pins

### DIFF
--- a/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
+++ b/arch/arm/boot/dts/overlays/revpi-connect4-overlay.dts
@@ -22,8 +22,8 @@
 				connect-gpios = <&gpio 6 GPIO_ACTIVE_HIGH>,
 						<&gpio 16 GPIO_ACTIVE_HIGH>;
 
-				left-sniff-gpios = <&expander_core 9 GPIO_ACTIVE_HIGH>,
-						   <&expander_core 8 GPIO_ACTIVE_HIGH>;
+				left-sniff-gpios = <&expander_core 8 GPIO_ACTIVE_HIGH>,
+						   <&expander_core 9 GPIO_ACTIVE_HIGH>;
 				right-sniff-gpios = <&expander_core 12 GPIO_ACTIVE_HIGH>,
 						   <&expander_core 11 GPIO_ACTIVE_HIGH>;
 			};


### PR DESCRIPTION
In the Connect 4 series design, the sniff pins on the left side are reversed. Change sniff and ack in order to make module discovery work again.