### PR TITLE
CI: Use legacy piControl branch for snapshots

### DIFF
--- a/.github/workflows/snapshot-packages.yml
+++ b/.github/workflows/snapshot-packages.yml
@@ -12,7 +12,7 @@ jobs:
     uses:  RevolutionPi/ci-workflows/.github/workflows/kernel-snapshot.yml@main
     with:
       kernelbakery_branch: master
-      picontrol_branch: master
+      picontrol_branch: revpi-5.10
       build_commit: ${{ github.event.pull_request.head.sha }}
       arch: arm
   kernelbakery_snapshot_arm64:
@@ -23,7 +23,7 @@ jobs:
     uses:  RevolutionPi/ci-workflows/.github/workflows/kernel-snapshot.yml@main
     with:
       kernelbakery_branch: master
-      picontrol_branch: master
+      picontrol_branch: revpi-5.10
       build_commit: ${{ github.event.pull_request.head.sha }}
       arch: arm64
   # link_artifacts:


### PR DESCRIPTION
With the migration torwards serdev based piControl, the snapshot packages must be build with the revpi-5.10 legacy piControl branch.

@l1k  This must NOT be backported to `revpi-6.1` (only for non-serdev kernels).

**NOTE: ONLY MERGE AFTER https://github.com/RevolutionPi/piControl/pull/97 HAS BEEN MERGED**