### PR TITLE
rtc: pcf2127: Disable time stamping support

### DIFF
--- a/drivers/rtc/rtc-pcf2127.c
+++ b/drivers/rtc/rtc-pcf2127.c
@@ -635,6 +635,7 @@ static int pcf2127_probe(struct device *dev, struct regmap *regmap,
 			 int alarm_irq, const char *name, bool is_pcf2127)
 {
 	struct pcf2127 *pcf2127;
+	bool ts_off = true;
 	int ret = 0;
 	unsigned int val;
 
@@ -766,6 +767,7 @@ static int pcf2127_probe(struct device *dev, struct regmap *regmap,
 	ret = regmap_update_bits(pcf2127->regmap, PCF2127_REG_TS_CTRL,
 				 PCF2127_BIT_TS_CTRL_TSOFF |
 				 PCF2127_BIT_TS_CTRL_TSM,
+				 ts_off ? PCF2127_BIT_TS_CTRL_TSOFF : 0 |
 				 PCF2127_BIT_TS_CTRL_TSM);
 	if (ret) {
 		dev_err(dev, "%s: tamper detection config (ts_ctrl) failed\n",
@@ -773,25 +775,38 @@ static int pcf2127_probe(struct device *dev, struct regmap *regmap,
 		return ret;
 	}
 
-	/*
-	 * Enable interrupt generation when TSF1 or TSF2 timestamp flags
-	 * are set. Interrupt signal is an open-drain output and can be
-	 * left floating if unused.
-	 */
-	ret = regmap_update_bits(pcf2127->regmap, PCF2127_REG_CTRL2,
-				 PCF2127_BIT_CTRL2_TSIE,
-				 PCF2127_BIT_CTRL2_TSIE);
-	if (ret) {
-		dev_err(dev, "%s: tamper detection config (ctrl2) failed\n",
-			__func__);
-		return ret;
-	}
+	if (ts_off) {
+		/* Clear timestamping interrupt flags */
+		ret = regmap_clear_bits(pcf2127->regmap, PCF2127_REG_CTRL1,
+					PCF2127_BIT_CTRL1_TSF1);
+		if (ret)
+			return ret;
 
-	ret = rtc_add_group(pcf2127->rtc, &pcf2127_attr_group);
-	if (ret) {
-		dev_err(dev, "%s: tamper sysfs registering failed\n",
-			__func__);
-		return ret;
+		ret = regmap_clear_bits(pcf2127->regmap, PCF2127_REG_CTRL2,
+					PCF2127_BIT_CTRL2_TSF2);
+		if (ret)
+			return ret;
+	} else {
+		/*
+		 * Enable interrupt generation when TSF1 or TSF2 timestamp flags
+		 * are set. Interrupt signal is an open-drain output and can be
+		 * left floating if unused.
+		 */
+		ret = regmap_update_bits(pcf2127->regmap, PCF2127_REG_CTRL2,
+					 PCF2127_BIT_CTRL2_TSIE,
+					 PCF2127_BIT_CTRL2_TSIE);
+		if (ret) {
+			dev_err(dev, "%s: tamper detection config (ctrl2) failed\n",
+				__func__);
+			return ret;
+		}
+
+		ret = rtc_add_group(pcf2127->rtc, &pcf2127_attr_group);
+		if (ret) {
+			dev_err(dev, "%s: tamper sysfs registering failed\n",
+				__func__);
+			return ret;
+		}
 	}
 
 	return devm_rtc_register_device(pcf2127->rtc);


### PR DESCRIPTION
For the watchdog to work all interrupt flags need to be cleared. If any interrupt flag is set the watchdog counter will stop at 1 and will not trigger a watchdog reset.

The timestamp feature of the PCF2127/PCF2129 can set two different interrupt flags. The TSF1 is set when the TS input is driven to an intermediate level between power supply and ground. And the TSF2 is set when TS input is driven to ground.

When the main power is removed and the power switches to the battery this bit might get set. It is unclear why this happens as neither the condition for TSF2 or TSF1 should apply in this case. The TS has an internal pull-up. If the TS pin in not connected should always have the same level as the power supply. And the current on the TS pin should never drop to ground level.

The second assumption, about the TSF2 seems to be true. But the TSF1 is set after a power cycle (on some devices). And this prevents a reliable use of the watchdog.

Disable the time stamping feature for now. As we don't have any device which has the TS connected. This is needed for the Connect 4 watchdog to work properly.